### PR TITLE
ESC-230 support date range in retreive subsidies requests

### DIFF
--- a/app/uk/gov/hmrc/eusubsidycompliance/connectors/DesHelpers.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliance/connectors/DesHelpers.scala
@@ -44,7 +44,6 @@ trait DesHelpers {
   def desPost[I, O](url: String, body: I, eisTokenKey: String)(implicit wts: Writes[I], rds: HttpReads[O], hc: HeaderCarrier, ec: ExecutionContext): Future[O] =
     http.POST[I, O](url, body, headers(eisTokenKey))(wts, rds, addHeaders, ec)
 
-  // TODO - can we make this an implicit def - is this *really* needed?
   def addHeaders(implicit hc: HeaderCarrier): HeaderCarrier = {
     hc.copy(authorization = None)
   }

--- a/app/uk/gov/hmrc/eusubsidycompliance/connectors/DesHelpers.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliance/connectors/DesHelpers.scala
@@ -44,6 +44,7 @@ trait DesHelpers {
   def desPost[I, O](url: String, body: I, eisTokenKey: String)(implicit wts: Writes[I], rds: HttpReads[O], hc: HeaderCarrier, ec: ExecutionContext): Future[O] =
     http.POST[I, O](url, body, headers(eisTokenKey))(wts, rds, addHeaders, ec)
 
+  // TODO - can we make this an implicit def - is this *really* needed?
   def addHeaders(implicit hc: HeaderCarrier): HeaderCarrier = {
     hc.copy(authorization = None)
   }

--- a/app/uk/gov/hmrc/eusubsidycompliance/connectors/EisConnector.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliance/connectors/EisConnector.scala
@@ -41,7 +41,7 @@ class EisConnector @Inject()(
 ) extends DesHelpers {
 
   val logger: Logger = Logger(this.getClass)
-  val eisURL: String = servicesConfig.baseUrl("eis")
+  lazy val eisURL: String = servicesConfig.baseUrl("eis")
 
   val retrieveUndertakingPath = "scp/retrieveundertaking/v1"
   val createUndertakingPath = "scp/createundertaking/v1"

--- a/app/uk/gov/hmrc/eusubsidycompliance/connectors/EisConnector.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliance/connectors/EisConnector.scala
@@ -135,17 +135,20 @@ class EisConnector @Inject()(
     )(implicitly, implicitly, addHeaders, implicitly)
   }
 
-  def retrieveSubsidies(ref: UndertakingRef)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[UndertakingSubsidies] = {
+  def retrieveSubsidies(
+    ref: UndertakingRef,
+    // TODO - should we apply defaults here?
+    dateRange: Option[(LocalDate, LocalDate)] = Some((LocalDate.of(2000, 1, 1), LocalDate.now()))
+  )(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[UndertakingSubsidies] = {
+
     import uk.gov.hmrc.eusubsidycompliance.models.json.eis.eisRetrieveUndertakingSubsidiesResponseWrite
 
     val eisTokenKey = "eis.token.scp09"
 
     desPost[SubsidyRetrieve, UndertakingSubsidies](
       s"$eisURL/$retrieveSubsidyPath",
-      SubsidyRetrieve(
-        ref,
-        Some((LocalDate.of(2000, 1, 1), LocalDate.now()))
-      ), eisTokenKey
+      SubsidyRetrieve(ref, dateRange),
+      eisTokenKey
     )(implicitly, implicitly, addHeaders, implicitly)
   }
 

--- a/app/uk/gov/hmrc/eusubsidycompliance/connectors/EisConnector.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliance/connectors/EisConnector.scala
@@ -38,7 +38,6 @@ class EisConnector @Inject()(
   val mode: Mode,
   val servicesConfig: ServicesConfig,
   val auditing: AuditConnector,
-  ec: ExecutionContext
 ) extends DesHelpers {
 
   val logger: Logger = Logger(this.getClass)
@@ -52,12 +51,8 @@ class EisConnector @Inject()(
   val amendSubsidyPath = "scp/amendundertakingsubsidyusage/v1"
   val retrieveSubsidyPath = "scp/getundertakingtransactions/v1"
 
-  def retrieveUndertaking(
-    eori: EORI
-  )(
-    implicit hc: HeaderCarrier,
-    ec: ExecutionContext
-  ): Future[Undertaking] = {
+  def retrieveUndertaking(eori: EORI)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Undertaking] = {
+
     import uk.gov.hmrc.eusubsidycompliance.models.json.digital.{retrieveUndertakingEORIWrites, undertakingFormat}
 
     val eisTokenKey = "eis.token.scp04"
@@ -71,13 +66,10 @@ class EisConnector @Inject()(
     }
   }
 
-  def createUndertaking(
-    undertaking: Undertaking
-  )(
-    implicit hc: HeaderCarrier,
-    ec: ExecutionContext
-  ): Future[UndertakingRef] = {
+  def createUndertaking(undertaking: Undertaking)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[UndertakingRef] = {
+
     import uk.gov.hmrc.eusubsidycompliance.models.json.digital.{undertakingCreateResponseReads, undertakingFormat}
+
     val eisTokenKey = "eis.token.scp02"
     desPost[Undertaking, UndertakingRef](
       s"$eisURL/$createUndertakingPath",
@@ -85,10 +77,10 @@ class EisConnector @Inject()(
     )(implicitly, implicitly, addHeaders, implicitly)
   }
 
-  def updateUndertaking(undertaking: Undertaking
-                       )(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[UndertakingRef]= {
+  def updateUndertaking(undertaking: Undertaking)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[UndertakingRef] = {
 
    import uk.gov.hmrc.eusubsidycompliance.models.json.digital.undertakingUpdateResponseReads
+
    val updateWrites: Writes[Undertaking] = updateUndertakingWrites()
     val eisTokenKey = "eis.token.scp12"
     desPost[Undertaking, UndertakingRef](
@@ -98,15 +90,12 @@ class EisConnector @Inject()(
   }
 
   def addMember(
-     undertakingRef: UndertakingRef,
-     businessEntity: BusinessEntity,
-     amendmentType: AmendmentType
-  )(
-    implicit hc: HeaderCarrier,
-    ec: ExecutionContext
-  ): Future[Unit] = {
+    undertakingRef: UndertakingRef,
+    businessEntity: BusinessEntity,
+    amendmentType: AmendmentType
+  )(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Unit] = {
 
-    import uk.gov.hmrc.eusubsidycompliance.models.json.digital.{amendUndertakingMemberDataResponseReads, amendUndertakingMemberDataWrites}
+    import uk.gov.hmrc.eusubsidycompliance.models.json.digital.amendUndertakingMemberDataWrites
 
     val eisTokenKey = "eis.token.scp05"
     desPost[UndertakingBusinessEntityUpdate, Unit](
@@ -119,16 +108,14 @@ class EisConnector @Inject()(
   }
 
   def deleteMember(
-     undertakingRef: UndertakingRef,
-     businessEntity: BusinessEntity
-   )(
-     implicit hc: HeaderCarrier,
-     ec: ExecutionContext
-   ): Future[Unit] = {
+    undertakingRef: UndertakingRef,
+    businessEntity: BusinessEntity
+  )(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Unit] = {
 
-    import uk.gov.hmrc.eusubsidycompliance.models.json.digital.{amendUndertakingMemberDataResponseReads, amendUndertakingMemberDataWrites}
+    import uk.gov.hmrc.eusubsidycompliance.models.json.digital.amendUndertakingMemberDataWrites
 
     val eisTokenKey = "eis.token.scp05"
+
     desPost[UndertakingBusinessEntityUpdate, Unit](
       s"$eisURL/$amendBusinessEntityPath",
       UndertakingBusinessEntityUpdate(
@@ -138,31 +125,20 @@ class EisConnector @Inject()(
     )(implicitly, implicitly, addHeaders, implicitly)
   }
 
-  def updateSubsidy(
-    subsidyUpdate: SubsidyUpdate
-  )(
-    implicit hc: HeaderCarrier,
-    ec: ExecutionContext
-  ): Future[Unit] = {
-
-    import uk.gov.hmrc.eusubsidycompliance.models.json.digital.amendSubsidyResponseReads
+  def updateSubsidy(subsidyUpdate: SubsidyUpdate)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Unit] = {
 
     val eisTokenKey = "eis.token.scp06"
+
     desPost[SubsidyUpdate, Unit](
       s"$eisURL/$amendSubsidyPath",
       subsidyUpdate, eisTokenKey
     )(implicitly, implicitly, addHeaders, implicitly)
   }
 
-  // TODO - modify this to accept date range.
-  def retrieveSubsidies(
-                       ref: UndertakingRef
-                       )(
-    implicit hc: HeaderCarrier,
-    ec: ExecutionContext
-                       ): Future[UndertakingSubsidies] = {
-    val eisTokenKey = "eis.token.scp09"
+  def retrieveSubsidies(ref: UndertakingRef)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[UndertakingSubsidies] = {
     import uk.gov.hmrc.eusubsidycompliance.models.json.eis.eisRetrieveUndertakingSubsidiesResponseWrite
+
+    val eisTokenKey = "eis.token.scp09"
 
     desPost[SubsidyRetrieve, UndertakingSubsidies](
       s"$eisURL/$retrieveSubsidyPath",

--- a/app/uk/gov/hmrc/eusubsidycompliance/connectors/EisConnector.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliance/connectors/EisConnector.scala
@@ -137,17 +137,18 @@ class EisConnector @Inject()(
 
   def retrieveSubsidies(
     ref: UndertakingRef,
-    // TODO - should we apply defaults here?
-    dateRange: Option[(LocalDate, LocalDate)] = Some((LocalDate.of(2000, 1, 1), LocalDate.now()))
+    dateRange: Option[(LocalDate, LocalDate)]
   )(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[UndertakingSubsidies] = {
 
     import uk.gov.hmrc.eusubsidycompliance.models.json.eis.eisRetrieveUndertakingSubsidiesResponseWrite
 
     val eisTokenKey = "eis.token.scp09"
 
+    val defaultDateRange = Some((LocalDate.of(2000, 1, 1), LocalDate.now()))
+
     desPost[SubsidyRetrieve, UndertakingSubsidies](
       s"$eisURL/$retrieveSubsidyPath",
-      SubsidyRetrieve(ref, dateRange),
+      SubsidyRetrieve(ref, dateRange.orElse(defaultDateRange)),
       eisTokenKey
     )(implicitly, implicitly, addHeaders, implicitly)
   }

--- a/app/uk/gov/hmrc/eusubsidycompliance/controllers/UndertakingController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliance/controllers/UndertakingController.scala
@@ -101,10 +101,9 @@ class UndertakingController @Inject()(
     }
   }
 
-  // TODO - support date parameters
   def retrieveSubsidies(): Action[JsValue] = Action.async(parse.json) { implicit request =>
     withJsonBody[SubsidyRetrieve] { retrieve: SubsidyRetrieve =>
-      eis.retrieveSubsidies(retrieve.undertakingIdentifier).map{ e =>
+      eis.retrieveSubsidies(retrieve.undertakingIdentifier, retrieve.inDateRange).map{ e =>
         Ok(Json.toJson(e)) // TODO check error handling
       }
     }

--- a/app/uk/gov/hmrc/eusubsidycompliance/controllers/UndertakingController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliance/controllers/UndertakingController.scala
@@ -101,6 +101,7 @@ class UndertakingController @Inject()(
     }
   }
 
+  // TODO - should we validate the date range? (Is it being done already?)
   def retrieveSubsidies(): Action[JsValue] = Action.async(parse.json) { implicit request =>
     withJsonBody[SubsidyRetrieve] { retrieve: SubsidyRetrieve =>
       eis.retrieveSubsidies(retrieve.undertakingIdentifier, retrieve.inDateRange).map{ e =>

--- a/app/uk/gov/hmrc/eusubsidycompliance/controllers/UndertakingController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliance/controllers/UndertakingController.scala
@@ -101,8 +101,7 @@ class UndertakingController @Inject()(
     }
   }
 
-  // TODO - should we validate the date range? (Is it being done already?)
-  def retrieveSubsidies(): Action[JsValue] = Action.async(parse.json) { implicit request =>
+  def retrieveSubsidies(): Action[JsValue] = authenticator.authorisedWithJson(parse.json) { implicit request => _ =>
     withJsonBody[SubsidyRetrieve] { retrieve: SubsidyRetrieve =>
       eis.retrieveSubsidies(retrieve.undertakingIdentifier, retrieve.inDateRange).map{ e =>
         Ok(Json.toJson(e)) // TODO check error handling

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -6,19 +6,21 @@ import sbt._
 object AppDependencies {
 
   val compile = Seq(
-    "uk.gov.hmrc"             %% "bootstrap-backend-play-28"  % "5.13.0",
+    "uk.gov.hmrc"             %% "bootstrap-backend-play-28"  % "5.20.0",
     "uk.gov.hmrc.mongo"       %% "hmrc-mongo-play-28"         % "0.53.0",
     "org.typelevel"           %% "cats-core"                  % "2.6.1",
     "com.chuusai"             %% "shapeless"                  % "2.3.7"
   )
 
   val test = Seq(
-    "uk.gov.hmrc"             %% "bootstrap-test-play-28"     % "5.13.0"   % Test,
+    "uk.gov.hmrc"             %% "bootstrap-test-play-28"     % "5.20.0"   % Test,
     "uk.gov.hmrc.mongo"       %% "hmrc-mongo-test-play-28"    % "0.53.0"   % Test,
     "com.vladsch.flexmark"    %  "flexmark-all"               % "0.36.8"   % "test, it",
+    // TODO - remove mockito once all tests transitioned to scalamock
     "org.mockito"             %  "mockito-core"               % "3.9.0"    % Test,
     "org.scalatestplus"       %% "scalatestplus-mockito"      % "1.0.0-M2" % Test,
     // Need to use a slightly older version for compatibility with the play jackson deps using 2.10.5
     "com.github.tomakehurst"  %  "wiremock-jre8"              % "2.26.3"   % Test,
+    "org.scalamock"           %% "scalamock"                  % "5.2.0"    % Test
   )
 }

--- a/test/uk/gov/hmrc/eusubsidycompliance/connectors/EisConnectorSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliance/connectors/EisConnectorSpec.scala
@@ -30,6 +30,7 @@ import uk.gov.hmrc.eusubsidycompliance.test.Fixtures._
 import uk.gov.hmrc.eusubsidycompliance.test.util.WiremockSupport
 import uk.gov.hmrc.http.{HeaderCarrier, UpstreamErrorResponse}
 
+import java.time.LocalDate
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class EisConnectorSpec extends AnyWordSpecLike with Matchers with WiremockSupport with ScalaFutures
@@ -51,7 +52,7 @@ class EisConnectorSpec extends AnyWordSpecLike with Matchers with WiremockSuppor
              | "retrieveUndertakingResponse": {
              |   "responseCommon": {
              |     "status": "OK",
-             |     "processingDate": "$now"
+             |     "processingDate": "$fixedInstant"
              |   },
              |   "responseDetail": {
              |      "undertakingReference": "$undertakingReference",
@@ -80,7 +81,7 @@ class EisConnectorSpec extends AnyWordSpecLike with Matchers with WiremockSuppor
              | "retrieveUndertakingResponse": {
              |   "responseCommon": {
              |     "status": "NOT_OK",
-             |     "processingDate": "$now",
+             |     "processingDate": "$fixedInstant",
              |     "returnParameters": [{
              |       "paramName": "ERRORCODE",
              |       "paramValue": "107"
@@ -101,7 +102,7 @@ class EisConnectorSpec extends AnyWordSpecLike with Matchers with WiremockSuppor
              | "retrieveUndertakingResponse": {
              |   "responseCommon": {
              |     "status": "NOT_OK",
-             |     "processingDate": "$now"
+             |     "processingDate": "$fixedInstant"
              |   }
              | }
              |}""".stripMargin
@@ -137,48 +138,69 @@ class EisConnectorSpec extends AnyWordSpecLike with Matchers with WiremockSuppor
       }
     }
 
-    "retrieveSubsidies" should {
+    "retrieveSubsidies is called" should {
 
-      "return an UndertakingSubsidies instance for a valid request" in {
-        givenEisReturns(200, RetrieveSubsidyPath,
-          s"""{
-            | "getUndertakingTransactionResponse": {
-            |   "responseCommon": {
-            |     "status": "OK"
-            |   },
-            |   "responseDetail": {
-            |     "undertakingIdentifier": "$undertakingReference",
-            |     "nonHMRCSubsidyTotalEUR": "$subsidyAmount",
-            |     "nonHMRCSubsidyTotalGBP": "$subsidyAmount",
-            |     "hmrcSubsidyTotalEUR": "$subsidyAmount",
-            |     "hmrcSubsidyTotalGBP": "$subsidyAmount",
-            |     "nonHMRCSubsidyUsage": [ {
-            |       "subsidyUsageTransactionID": "$subsidyRef",
-            |       "allocationDate": "$date",
-            |       "submissionDate": "$date",
-            |       "publicAuthority": "$publicAuthority",
-            |       "traderReference": "$traderRef",
-            |       "nonHMRCSubsidyAmtEUR": $subsidyAmount,
-            |       "businessEntityIdentifier": "$eori"
-            |     } ],
-            |     "hmrcSubsidyUsage": [ {
-            |       "declarationID": "$declarationId",
-            |       "issueDate": "$date",
-            |       "acceptanceDate": "$date",
-            |       "declarantEORI": "$eori",
-            |       "consigneeEORI": "$eori",
-            |       "taxType": "$taxType",
-            |       "amount": $subsidyAmount,
-            |       "tradersOwnRefUCR": "$traderRef"
-            |     } ]
-            |   }
-            | }
-            |}
-            |""".stripMargin
-        )
+      val retrieveSubsidiesResponse = s"""{
+         | "getUndertakingTransactionResponse": {
+         |   "responseCommon": {
+         |     "status": "OK"
+         |   },
+         |   "responseDetail": {
+         |     "undertakingIdentifier": "$undertakingReference",
+         |     "nonHMRCSubsidyTotalEUR": "$subsidyAmount",
+         |     "nonHMRCSubsidyTotalGBP": "$subsidyAmount",
+         |     "hmrcSubsidyTotalEUR": "$subsidyAmount",
+         |     "hmrcSubsidyTotalGBP": "$subsidyAmount",
+         |     "nonHMRCSubsidyUsage": [ {
+         |       "subsidyUsageTransactionID": "$subsidyRef",
+         |       "allocationDate": "$date",
+         |       "submissionDate": "$date",
+         |       "publicAuthority": "$publicAuthority",
+         |       "traderReference": "$traderRef",
+         |       "nonHMRCSubsidyAmtEUR": $subsidyAmount,
+         |       "businessEntityIdentifier": "$eori"
+         |     } ],
+         |     "hmrcSubsidyUsage": [ {
+         |       "declarationID": "$declarationId",
+         |       "issueDate": "$date",
+         |       "acceptanceDate": "$date",
+         |       "declarantEORI": "$eori",
+         |       "consigneeEORI": "$eori",
+         |       "taxType": "$taxType",
+         |       "amount": $subsidyAmount,
+         |       "tradersOwnRefUCR": "$traderRef"
+         |     } ]
+         |   }
+         | }
+         |}
+         |""".stripMargin
+
+
+      "return an UndertakingSubsidies instance for a valid request without specifying a date range" in {
+
+        // When no date is specified the connector falls back to a range of 2000-01-01 to LocalDate.now()
+        val requestBody = retrieveSubsidiesRequestWithDates(LocalDate.of(2000, 1, 1), LocalDate.now())
+
+        givenEisReturns(200, RetrieveSubsidyPath, requestBody, retrieveSubsidiesResponse)
 
         testWithRunningApp { underTest =>
           underTest.retrieveSubsidies(undertakingReference).futureValue mustBe undertakingSubsidies
+        }
+      }
+
+      "return an UndertakingSubsidies instance for a valid request with a date range" in {
+
+        val toDate = date.plusDays(7)
+
+        val requestBody = retrieveSubsidiesRequestWithDates(date, date.plusDays(7))
+
+        givenEisReturns(200, RetrieveSubsidyPath, requestBody, retrieveSubsidiesResponse)
+
+        testWithRunningApp { underTest =>
+          underTest.retrieveSubsidies(
+            undertakingReference,
+            Some((date, toDate))
+          ).futureValue mustBe undertakingSubsidies
         }
       }
 
@@ -217,11 +239,32 @@ class EisConnectorSpec extends AnyWordSpecLike with Matchers with WiremockSuppor
           .withBody(body)
       ))
 
+  private def givenEisReturns(status: Int, url: String, requestBody: String, responseBody: String): Unit =
+    server.stubFor(
+      post(urlEqualTo(url))
+        .withRequestBody(equalToJson(requestBody))
+        .willReturn(aResponse()
+          .withStatus(status)
+          .withBody(responseBody)
+        ))
+
   private def testWithRunningApp(f: EisConnector => Unit): Unit = {
     val app = configuredApplication
     running(app) {
      f(app.injector.instanceOf[EisConnector])
     }
   }
+
+  private def retrieveSubsidiesRequestWithDates(from: LocalDate, to: LocalDate) =
+    s"""{
+       |  "undertakingIdentifier": "$undertakingReference",
+       |  "getNonHMRCUsageTransaction": true,
+       |  "getHMRCUsageTransaction": true,
+       |  "dateFromNonHMRCSubsidyUsage": "$from",
+       |  "dateFromHMRCSubsidyUsage": "$from",
+       |  "dateToNonHMRCSubsidyUsage": "$to",
+       |  "dateToHMRCSubsidyUsage": "$to"
+       |}
+       |""".stripMargin
 
 }

--- a/test/uk/gov/hmrc/eusubsidycompliance/connectors/EisConnectorSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliance/connectors/EisConnectorSpec.scala
@@ -184,7 +184,7 @@ class EisConnectorSpec extends AnyWordSpecLike with Matchers with WiremockSuppor
         givenEisReturns(200, RetrieveSubsidyPath, requestBody, retrieveSubsidiesResponse)
 
         testWithRunningApp { underTest =>
-          underTest.retrieveSubsidies(undertakingReference).futureValue mustBe undertakingSubsidies
+          underTest.retrieveSubsidies(undertakingReference, None).futureValue mustBe undertakingSubsidies
         }
       }
 
@@ -208,7 +208,7 @@ class EisConnectorSpec extends AnyWordSpecLike with Matchers with WiremockSuppor
         givenEisReturns(500, RetrieveSubsidyPath, "Internal Server Error")
 
         testWithRunningApp { underTest =>
-          underTest.retrieveSubsidies(undertakingReference).failed.futureValue mustBe a[UpstreamErrorResponse]
+          underTest.retrieveSubsidies(undertakingReference, None).failed.futureValue mustBe a[UpstreamErrorResponse]
         }
       }
 
@@ -216,7 +216,7 @@ class EisConnectorSpec extends AnyWordSpecLike with Matchers with WiremockSuppor
         givenEisReturns(200, RetrieveSubsidyPath, "This is not a valid response")
 
         testWithRunningApp { underTest =>
-          underTest.retrieveSubsidies(undertakingReference).failed.futureValue mustBe a[JsonParseException]
+          underTest.retrieveSubsidies(undertakingReference, None).failed.futureValue mustBe a[JsonParseException]
         }
       }
 

--- a/test/uk/gov/hmrc/eusubsidycompliance/controllers/UndertakingControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliance/controllers/UndertakingControllerSpec.scala
@@ -17,56 +17,49 @@
 package uk.gov.hmrc.eusubsidycompliance.controllers
 
 import org.scalamock.scalatest.MockFactory
+import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatestplus.play.PlaySpec
+import play.api.http.Status
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.Json
-import play.api.mvc.{ControllerComponents, Request, Result, Results}
-import play.api.test.FakeRequest
+import play.api.mvc.{ControllerComponents, Request, Result}
+import play.api.test.{FakeRequest, Helpers}
 import play.api.test.Helpers._
 import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.eusubsidycompliance.connectors.EisConnector
 import uk.gov.hmrc.eusubsidycompliance.controllers.actions.Auth
-import uk.gov.hmrc.eusubsidycompliance.models.SubsidyRetrieve
+import uk.gov.hmrc.eusubsidycompliance.models.{SubsidyRetrieve, UndertakingSubsidies}
 import uk.gov.hmrc.eusubsidycompliance.models.types.UndertakingRef
-import uk.gov.hmrc.eusubsidycompliance.test.Fixtures.{eori, undertakingReference, undertakingSubsidies}
+import uk.gov.hmrc.eusubsidycompliance.test.Fixtures.{date, eori, undertakingReference, undertakingSubsidies}
 import uk.gov.hmrc.http.HeaderCarrier
 
 import java.time.LocalDate
 import scala.concurrent.{ExecutionContext, Future}
 
-class UndertakingControllerSpec extends PlaySpec with MockFactory with Results {
+class UndertakingControllerSpec extends PlaySpec with MockFactory with ScalaFutures with IntegrationPatience {
 
+  // FakeAuthenticator that allows every request.
   private class FakeAuth extends Auth {
     override def authCommon[A](
       action: AuthAction[A]
     )(implicit request: Request[A], executionContext: ExecutionContext): Future[Result] = action(request)(eori)
+    override protected def controllerComponents: ControllerComponents = Helpers.stubControllerComponents()
+    // This isn't used in this implementation so can be left as unimplemented.
     override def authConnector: AuthConnector = ???
-    override protected def controllerComponents: ControllerComponents = ???
   }
+
+  private val mockEisConnector = mock[EisConnector]
 
   "UnderTakingController" when {
 
     "retrieve subsidies is called" should {
 
-      "return a valid response for a successful request" in {
+      "return a valid response for a successful request with no date range" in {
 
-        val mockEisConnector = mock[EisConnector]
+        givenRetrieveSubsidiesReturns(Future.successful(undertakingSubsidies))
 
-        (mockEisConnector.retrieveSubsidies(_: UndertakingRef, _: Option[(LocalDate, LocalDate)])(_: HeaderCarrier, _: ExecutionContext))
-          .expects(undertakingReference, *, *, *)
-          .returning(Future.successful(undertakingSubsidies))
-
-        val app = new GuiceApplicationBuilder()
-          .configure(
-            "metrics.jvm" -> false,
-            "microservice.metrics.graphite.enabled" -> false,
-          )
-          .overrides(
-            bind[EisConnector].to(mockEisConnector),
-            bind[Auth].to(new FakeAuth)
-          )
-          .build()
+        val app = configuredAppInstance
 
         running(app) {
 
@@ -75,13 +68,75 @@ class UndertakingControllerSpec extends PlaySpec with MockFactory with Results {
             .withHeaders("Content-type" -> "application/json")
 
           val result = route(app, request).value
-          status(result) mustBe 200
 
+          status(result) mustBe Status.OK
+          contentAsJson(result) mustBe Json.toJson(undertakingSubsidies)
+        }
+      }
+
+      "return a valid response for a successful request with a date range" in {
+
+        givenRetrieveSubsidiesReturns(Future.successful(undertakingSubsidies))
+
+        val app = configuredAppInstance
+
+        running(app) {
+          val request = FakeRequest(POST, routes.UndertakingController.retrieveSubsidies().url)
+            .withJsonBody(Json.toJson( SubsidyRetrieve(undertakingReference, Some((date, date.plusDays(7))))))
+            .withHeaders("Content-type" -> "application/json")
+
+          val result = route(app, request).value
+
+          status(result) mustBe Status.OK
+          contentAsJson(result) mustBe Json.toJson(undertakingSubsidies)
+        }
+      }
+
+      "throw an exception if the call to EIS fails" in {
+        givenRetrieveSubsidiesReturns(Future.failed(new RuntimeException("Something failed")))
+
+        val app = configuredAppInstance
+
+        running(app) {
+          val request = FakeRequest(POST, routes.UndertakingController.retrieveSubsidies().url)
+            .withJsonBody(Json.toJson( SubsidyRetrieve(undertakingReference, Some((date, date.plusDays(7))))))
+            .withHeaders("Content-type" -> "application/json")
+
+          route(app, request).value.failed.futureValue mustBe a[RuntimeException]
+        }
+      }
+
+      "return a HTTP 400 if the request body is invalid" in {
+        val app = configuredAppInstance
+
+        running(app) {
+          val request = FakeRequest(POST, routes.UndertakingController.retrieveSubsidies().url)
+            .withBody("This is not valid JSON")
+            .withHeaders("Content-type" -> "application/json")
+
+          status(route(app, request).value) mustBe Status.BAD_REQUEST
         }
       }
 
     }
 
   }
+
+  private def configuredAppInstance = new GuiceApplicationBuilder()
+    .configure(
+      "metrics.jvm" -> false,
+      "microservice.metrics.graphite.enabled" -> false,
+    )
+    .overrides(
+      bind[EisConnector].to(mockEisConnector),
+      bind[Auth].to(new FakeAuth)
+    )
+    .build()
+
+
+  private def givenRetrieveSubsidiesReturns(res: Future[UndertakingSubsidies]): Unit =
+    (mockEisConnector.retrieveSubsidies(_: UndertakingRef, _: Option[(LocalDate, LocalDate)])(_: HeaderCarrier, _: ExecutionContext))
+      .expects(undertakingReference, *, *, *)
+      .returning(res)
 
 }

--- a/test/uk/gov/hmrc/eusubsidycompliance/controllers/UndertakingControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliance/controllers/UndertakingControllerSpec.scala
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.eusubsidycompliance.controllers
+
+import org.scalamock.scalatest.MockFactory
+import org.scalatestplus.play.PlaySpec
+import play.api.inject.bind
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.json.Json
+import play.api.mvc.{ControllerComponents, Request, Result, Results}
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import uk.gov.hmrc.auth.core.AuthConnector
+import uk.gov.hmrc.eusubsidycompliance.connectors.EisConnector
+import uk.gov.hmrc.eusubsidycompliance.controllers.actions.Auth
+import uk.gov.hmrc.eusubsidycompliance.models.SubsidyRetrieve
+import uk.gov.hmrc.eusubsidycompliance.models.types.UndertakingRef
+import uk.gov.hmrc.eusubsidycompliance.test.Fixtures.{eori, undertakingReference, undertakingSubsidies}
+import uk.gov.hmrc.http.HeaderCarrier
+
+import java.time.LocalDate
+import scala.concurrent.{ExecutionContext, Future}
+
+class UndertakingControllerSpec extends PlaySpec with MockFactory with Results {
+
+  private class FakeAuth extends Auth {
+    override def authCommon[A](
+      action: AuthAction[A]
+    )(implicit request: Request[A], executionContext: ExecutionContext): Future[Result] = action(request)(eori)
+    override def authConnector: AuthConnector = ???
+    override protected def controllerComponents: ControllerComponents = ???
+  }
+
+  "UnderTakingController" when {
+
+    "retrieve subsidies is called" should {
+
+      "return a valid response for a successful request" in {
+
+        val mockEisConnector = mock[EisConnector]
+
+        (mockEisConnector.retrieveSubsidies(_: UndertakingRef, _: Option[(LocalDate, LocalDate)])(_: HeaderCarrier, _: ExecutionContext))
+          .expects(undertakingReference, *, *, *)
+          .returning(Future.successful(undertakingSubsidies))
+
+        val app = new GuiceApplicationBuilder()
+          .configure(
+            "metrics.jvm" -> false,
+            "microservice.metrics.graphite.enabled" -> false,
+          )
+          .overrides(
+            bind[EisConnector].to(mockEisConnector),
+            bind[Auth].to(new FakeAuth)
+          )
+          .build()
+
+        running(app) {
+
+          val request = FakeRequest(POST, routes.UndertakingController.retrieveSubsidies().url)
+            .withJsonBody(Json.toJson( SubsidyRetrieve(undertakingReference, None)))
+            .withHeaders("Content-type" -> "application/json")
+
+          val result = route(app, request).value
+          status(result) mustBe 200
+
+        }
+      }
+
+    }
+
+  }
+
+}

--- a/test/uk/gov/hmrc/eusubsidycompliance/controllers/actions/AuthTestSupport.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliance/controllers/actions/AuthTestSupport.scala
@@ -25,6 +25,7 @@ import uk.gov.hmrc.auth.core.{AuthConnector, Enrolments}
 import scala.concurrent.Future
 
 trait AuthTestSupport extends MockitoSugar {
+
   lazy val mockAuthConnector: AuthConnector = mock[AuthConnector]
 
   def withAuthorizedUser(enrolments: Enrolments = Enrolments(Set.empty)): Unit = {

--- a/test/uk/gov/hmrc/eusubsidycompliance/controllers/actions/AuthenticatorSpecs.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliance/controllers/actions/AuthenticatorSpecs.scala
@@ -17,12 +17,17 @@
 package uk.gov.hmrc.eusubsidycompliance.controllers.actions
 
 import org.scalatest.EitherValues
+import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.matchers.should.Matchers._
 import org.scalatest.wordspec.AnyWordSpec
 import play.api.http.Status
+import play.api.inject.bind
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.json.Json
+import play.api.mvc.Result
 import play.api.mvc.Results.Ok
-import play.api.test.Helpers.{await, status}
+import play.api.test.Helpers._
 import play.api.test.{DefaultAwaitTimeout, FakeRequest}
 import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
@@ -30,52 +35,88 @@ import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, Future}
 
 class AuthenticatorSpecs extends AnyWordSpec with Matchers with AuthTestSupport
-  with DefaultAwaitTimeout with EitherValues  {
+  with DefaultAwaitTimeout with EitherValues with ScalaFutures {
 
   private val mcc = stubMessagesControllerComponents()
   private val request = FakeRequest()
   private val authenticator = new AuthImpl(mockAuthConnector, mcc)
   private val requestWithAuthHeader = request.withHeaders(("Authorization", "XXXX"))
 
-  implicit val ec: ExecutionContextExecutor = ExecutionContext.global
+  // Simple case class to validate request body deserialization.
+  private case class Foo(bar: String)
+  private implicit val fooFormat = Json.format[Foo]
 
-  private def result = authenticator.authorised { _ => _ => Future.successful(Ok("Hello world")) }
+  private val requestWithAuthHeaderAndJsonBody =
+    requestWithAuthHeader.withJsonBody(Json.toJson(Foo("Bar")))
+      .withHeaders("Content-type" -> "application/json")
+      .withMethod(POST)
+
+  private implicit val ec: ExecutionContextExecutor = ExecutionContext.global
+
+  private val actionResponse = "Hello world"
+
+  private def handleRequestWithNoBody = authenticator.authorised { _ => _ => Future.successful(Ok(actionResponse)) }
+
+  private def handleRequestWithJsonBody = authenticator.
+    authorisedWithJson(mcc.parsers.json) { _ => _ => Future.successful(Ok(actionResponse)) }
 
   private def newEnrolment(identifierName: String, identifierValue: String) =
     Enrolment("HMRC-ESC-ORG").withIdentifier(identifierName, identifierValue)
 
   "Authentication" should {
+
     "return Forbidden when there is no Authorization header" in {
-      status(result(request)) shouldBe Status.FORBIDDEN
+      status(handleRequestWithNoBody(request)) shouldBe Status.FORBIDDEN
     }
 
-    "return 200 Ok" in {
+    "return 200 Ok for a valid request without a JSON body" in {
       withAuthorizedUser(Enrolments(Set(newEnrolment("EORINumber", "GB123123123123"))))
-      status(result(requestWithAuthHeader)) shouldBe Status.OK
+      status(handleRequestWithNoBody(requestWithAuthHeader)) shouldBe Status.OK
+    }
+
+    "return 200 Ok for a valid request with a JSON body" in {
+      withAuthorizedUser(Enrolments(Set(newEnrolment("EORINumber", "GB123123123123"))))
+
+      val app = new GuiceApplicationBuilder()
+        .configure(
+          "metrics.jvm" -> false,
+          "microservice.metrics.graphite.enabled" -> false,
+        )
+        .overrides(
+          bind[AuthConnector].to(mockAuthConnector))
+        .build()
+
+      running(app) {
+        import app.materializer
+        val result = call(handleRequestWithJsonBody, req = requestWithAuthHeaderAndJsonBody)
+        status(result) shouldBe 200
+        contentAsString(result) shouldBe actionResponse
+      }
     }
 
     "throw illegal state error exception " in {
       withAuthorizedUser()
       assertThrows[IllegalStateException](
-        await(result(requestWithAuthHeader))
+        await(handleRequestWithNoBody(requestWithAuthHeader))
       )
     }
 
     "throw illegal state exception when identifier missing" in {
       withAuthorizedUser(Enrolments(Set(newEnrolment("XXX", "XXX"))))
       assertThrows[IllegalStateException](
-        await(result(requestWithAuthHeader))
+        await(handleRequestWithNoBody(requestWithAuthHeader))
       )
     }
 
     "return 401 UNAUTHORIZED when there are insufficient enrolments" in {
       withUnauthorizedUser(InsufficientEnrolments("User not authorised"))
-      status(result(requestWithAuthHeader)) shouldBe Status.UNAUTHORIZED
+      status(handleRequestWithNoBody(requestWithAuthHeader)) shouldBe Status.UNAUTHORIZED
     }
 
     "return 401 UNAUTHORIZED when there is no session record" in {
       withUnauthorizedUser(SessionRecordNotFound("User not authorised"))
-      status(result(requestWithAuthHeader)) shouldBe Status.UNAUTHORIZED
+      status(handleRequestWithNoBody(requestWithAuthHeader)) shouldBe Status.UNAUTHORIZED
     }
+
   }
 }

--- a/test/uk/gov/hmrc/eusubsidycompliance/controllers/actions/AuthenticatorSpecs.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliance/controllers/actions/AuthenticatorSpecs.scala
@@ -24,8 +24,7 @@ import org.scalatest.wordspec.AnyWordSpec
 import play.api.http.Status
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
-import play.api.libs.json.Json
-import play.api.mvc.Result
+import play.api.libs.json.{Json, OFormat}
 import play.api.mvc.Results.Ok
 import play.api.test.Helpers._
 import play.api.test.{DefaultAwaitTimeout, FakeRequest}
@@ -34,8 +33,8 @@ import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, Future}
 
-class AuthenticatorSpecs extends AnyWordSpec with Matchers with AuthTestSupport
-  with DefaultAwaitTimeout with EitherValues with ScalaFutures {
+class AuthenticatorSpecs extends AnyWordSpec with Matchers with AuthTestSupport with DefaultAwaitTimeout
+  with EitherValues with ScalaFutures {
 
   private val mcc = stubMessagesControllerComponents()
   private val request = FakeRequest()
@@ -44,7 +43,7 @@ class AuthenticatorSpecs extends AnyWordSpec with Matchers with AuthTestSupport
 
   // Simple case class to validate request body deserialization.
   private case class Foo(bar: String)
-  private implicit val fooFormat = Json.format[Foo]
+  private implicit val fooFormat: OFormat[Foo] = Json.format[Foo]
 
   private val requestWithAuthHeaderAndJsonBody =
     requestWithAuthHeader.withJsonBody(Json.toJson(Foo("Bar")))
@@ -89,7 +88,7 @@ class AuthenticatorSpecs extends AnyWordSpec with Matchers with AuthTestSupport
       running(app) {
         import app.materializer
         val result = call(handleRequestWithJsonBody, req = requestWithAuthHeaderAndJsonBody)
-        status(result) shouldBe 200
+        status(result) shouldBe Status.OK
         contentAsString(result) shouldBe actionResponse
       }
     }

--- a/test/uk/gov/hmrc/eusubsidycompliance/test/Fixtures.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliance/test/Fixtures.scala
@@ -24,13 +24,13 @@ import java.time.{Instant, ZoneId}
 object Fixtures {
 
   val eori = EORI("GB123456789012")
-  val now = Instant.now()
+  val fixedInstant = Instant.parse("2022-01-01T12:00:00Z")
 
   val undertakingReference = UndertakingRef("SomeUndertakingReference")
   val undertakingName = UndertakingName("SomeUndertakingName")
   val sector = Sector.other
   val industrySectorLimit = IndustrySectorLimit(BigDecimal(200000.00))
-  val date = now.atZone(ZoneId.of("Europe/London")).toLocalDate
+  val date = fixedInstant.atZone(ZoneId.of("Europe/London")).toLocalDate
   val subsidyAmount = SubsidyAmount(BigDecimal(123.45))
 
   val undertaking = Undertaking(


### PR DESCRIPTION
Summary of changes
* add test coverage for `Auth.authorisedWithJson`
* revise `retrieveSubsidies` method of `UndertakingController` to pass date range from request down to `EISConnector`
* `EISConnector` now accepts a date range, otherwise it defaults to the original default date range
* updated `EISConnector` tests to cover date range support and failure cases
* added tests for the `retrieveSubsidides` method of `UndertakingController`
* other minor tidy ups