### PR TITLE
ESC-410 fix handling of NOT_OK responses where no data is being returned

### DIFF
--- a/app/uk/gov/hmrc/eusubsidycompliance/connectors/DesHelpers.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliance/connectors/DesHelpers.scala
@@ -52,10 +52,8 @@ trait DesHelpers {
     rds: HttpReads[O],
     hc: HeaderCarrier,
     ec: ExecutionContext
-  ): Future[O] = {
-    println(s"desPost writes: $wts reads: $rds")
+  ): Future[O] =
     http.POST[I, O](url, body, headers(eisTokenKey))(wts, rds, addHeaders, ec)
-  }
 
   def addHeaders(implicit hc: HeaderCarrier): HeaderCarrier =
     hc.copy(authorization = None)

--- a/app/uk/gov/hmrc/eusubsidycompliance/connectors/DesHelpers.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliance/connectors/DesHelpers.scala
@@ -52,8 +52,10 @@ trait DesHelpers {
     rds: HttpReads[O],
     hc: HeaderCarrier,
     ec: ExecutionContext
-  ): Future[O] =
+  ): Future[O] = {
+    println(s"desPost writes: $wts reads: $rds")
     http.POST[I, O](url, body, headers(eisTokenKey))(wts, rds, addHeaders, ec)
+  }
 
   def addHeaders(implicit hc: HeaderCarrier): HeaderCarrier =
     hc.copy(authorization = None)

--- a/app/uk/gov/hmrc/eusubsidycompliance/connectors/EisConnector.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliance/connectors/EisConnector.scala
@@ -104,11 +104,7 @@ class EisConnector @Inject() (
     amendmentType: AmendmentType
   )(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Unit] = {
 
-    println(s"AddMember: called with uref: $undertakingRef be: $businessEntity type: $amendmentType")
-
     import uk.gov.hmrc.eusubsidycompliance.models.json.digital.{amendUndertakingMemberDataResponseReads, amendUndertakingMemberDataWrites}
-
-    val thing = readFromJson(amendUndertakingMemberDataResponseReads, implicitly[Manifest[Unit]])
 
     val eisTokenKey = "eis.token.scp05"
 
@@ -120,8 +116,7 @@ class EisConnector @Inject() (
         List(BusinessEntityUpdate(amendmentType, LocalDate.now(), businessEntity))
       ),
       eisTokenKey
-    )(implicitly, thing, addHeaders, implicitly)
-    result.foreach(r => println(s"Got response: $r"))
+    )(implicitly, readFromJson(amendUndertakingMemberDataResponseReads, implicitly[Manifest[Unit]]), addHeaders, implicitly)
     result
   }
 
@@ -130,7 +125,7 @@ class EisConnector @Inject() (
     businessEntity: BusinessEntity
   )(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Unit] = {
 
-    import uk.gov.hmrc.eusubsidycompliance.models.json.digital.amendUndertakingMemberDataWrites
+    import uk.gov.hmrc.eusubsidycompliance.models.json.digital.{amendUndertakingMemberDataResponseReads, amendUndertakingMemberDataWrites}
 
     val eisTokenKey = "eis.token.scp05"
 
@@ -142,12 +137,14 @@ class EisConnector @Inject() (
         List(BusinessEntityUpdate(AmendmentType.delete, LocalDate.now(), businessEntity))
       ),
       eisTokenKey
-    )(implicitly, implicitly, addHeaders, implicitly)
+    )(implicitly, readFromJson(amendUndertakingMemberDataResponseReads, implicitly[Manifest[Unit]]), addHeaders, implicitly)
   }
 
   def upsertSubsidyUsage(
     subsidyUpdate: SubsidyUpdate
   )(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Unit] = {
+
+    import uk.gov.hmrc.eusubsidycompliance.models.json.digital.amendSubsidyResponseReads
 
     val eisTokenKey = "eis.token.scp06"
 
@@ -155,7 +152,7 @@ class EisConnector @Inject() (
       s"$eisURL/$amendSubsidyPath",
       subsidyUpdate,
       eisTokenKey
-    )(implicitly, implicitly, addHeaders, implicitly)
+    )(implicitly, readFromJson(amendSubsidyResponseReads, implicitly[Manifest[Unit]]), addHeaders, implicitly)
   }
 
   def retrieveSubsidies(

--- a/app/uk/gov/hmrc/eusubsidycompliance/connectors/EisConnector.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliance/connectors/EisConnector.scala
@@ -18,14 +18,14 @@ package uk.gov.hmrc.eusubsidycompliance.connectors
 
 import play.api.libs.json.Writes
 import play.api.{Logger, Mode}
+import uk.gov.hmrc.eusubsidycompliance.models._
 import uk.gov.hmrc.eusubsidycompliance.models.json.digital.{EisBadResponseException, updateUndertakingWrites}
 import uk.gov.hmrc.eusubsidycompliance.models.types.AmendmentType.AmendmentType
 import uk.gov.hmrc.eusubsidycompliance.models.types.{AmendmentType, EORI, EisParamValue, UndertakingRef}
-import uk.gov.hmrc.eusubsidycompliance.models._
+import uk.gov.hmrc.http.HttpReads.Implicits._
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, UpstreamErrorResponse}
 import uk.gov.hmrc.play.audit.http.connector.AuditConnector
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
-import uk.gov.hmrc.http.HttpReads.Implicits._
 
 import java.time.LocalDate
 import javax.inject.{Inject, Singleton}
@@ -39,16 +39,15 @@ class EisConnector @Inject() (
   val auditing: AuditConnector
 ) extends DesHelpers {
 
-  val logger: Logger = Logger(this.getClass)
-  lazy val eisURL: String = servicesConfig.baseUrl("eis")
+  private val logger: Logger = Logger(this.getClass)
+  private lazy val eisURL: String = servicesConfig.baseUrl("eis")
 
-  val retrieveUndertakingPath = "scp/retrieveundertaking/v1"
-  val createUndertakingPath = "scp/createundertaking/v1"
-  val updateUndertakingPath = "scp/updateundertaking/v1"
-  val amendBusinessEntityPath = "scp/amendundertakingmemberdata/v1"
-
-  val amendSubsidyPath = "scp/amendundertakingsubsidyusage/v1"
-  val retrieveSubsidyPath = "scp/getundertakingtransactions/v1"
+  private val retrieveUndertakingPath = "scp/retrieveundertaking/v1"
+  private val createUndertakingPath = "scp/createundertaking/v1"
+  private val updateUndertakingPath = "scp/updateundertaking/v1"
+  private val amendBusinessEntityPath = "scp/amendundertakingmemberdata/v1"
+  private val amendSubsidyPath = "scp/amendundertakingsubsidyusage/v1"
+  private val retrieveSubsidyPath = "scp/getundertakingtransactions/v1"
 
   def retrieveUndertaking(eori: EORI)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Undertaking] = {
 
@@ -105,10 +104,15 @@ class EisConnector @Inject() (
     amendmentType: AmendmentType
   )(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Unit] = {
 
-    import uk.gov.hmrc.eusubsidycompliance.models.json.digital.amendUndertakingMemberDataWrites
+    println(s"AddMember: called with uref: $undertakingRef be: $businessEntity type: $amendmentType")
+
+    import uk.gov.hmrc.eusubsidycompliance.models.json.digital.{amendUndertakingMemberDataResponseReads, amendUndertakingMemberDataWrites}
+
+    val thing = readFromJson(amendUndertakingMemberDataResponseReads, implicitly[Manifest[Unit]])
 
     val eisTokenKey = "eis.token.scp05"
-    desPost[UndertakingBusinessEntityUpdate, Unit](
+
+    val result = desPost[UndertakingBusinessEntityUpdate, Unit](
       s"$eisURL/$amendBusinessEntityPath",
       UndertakingBusinessEntityUpdate(
         undertakingRef,
@@ -116,7 +120,9 @@ class EisConnector @Inject() (
         List(BusinessEntityUpdate(amendmentType, LocalDate.now(), businessEntity))
       ),
       eisTokenKey
-    )(implicitly, implicitly, addHeaders, implicitly)
+    )(implicitly, thing, addHeaders, implicitly)
+    result.foreach(r => println(s"Got response: $r"))
+    result
   }
 
   def deleteMember(

--- a/app/uk/gov/hmrc/eusubsidycompliance/connectors/EisConnector.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliance/connectors/EisConnector.scala
@@ -51,7 +51,7 @@ class EisConnector @Inject() (
 
   def retrieveUndertaking(eori: EORI)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Undertaking] = {
 
-    import uk.gov.hmrc.eusubsidycompliance.models.json.digital.{retrieveUndertakingEORIWrites, undertakingFormat}
+    import uk.gov.hmrc.eusubsidycompliance.models.json.digital.{retrieveUndertakingEORIWrites, undertakingReads}
 
     val eisTokenKey = "eis.token.scp04"
     desPost[EORI, Undertaking](
@@ -73,7 +73,7 @@ class EisConnector @Inject() (
     undertaking: Undertaking
   )(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[UndertakingRef] = {
 
-    import uk.gov.hmrc.eusubsidycompliance.models.json.digital.{undertakingCreateResponseReads, undertakingFormat}
+    import uk.gov.hmrc.eusubsidycompliance.models.json.digital.{undertakingCreateResponseReads, undertakingWrites}
 
     val eisTokenKey = "eis.token.scp02"
     desPost[Undertaking, UndertakingRef](


### PR DESCRIPTION
Summary of changes
* fix incorrect implicit resolution for Unit responses so that the NOT_OK status is respected if a POST operation fails
* refactor the Reads code for these responses removing duplication of the OK/NOT_OK handling
* added additional tests around the affected endpoints to verify that a 500 is now returned when a NOT_OK response is received