### PR TITLE
ESC-443 enforce minimum 90% coverage limit

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,10 @@ lazy val microservice = Project(appName, file("."))
   .settings(
     ScoverageKeys.coverageExcludedFiles := "<empty>;Reverse.*;.*filters.*;.*handlers.*;.*components.*;.*repositories.*;" +
       ".*BuildInfo.*;.*javascript.*;.*Routes.*;.*models.*;.*config.*;.*TimeProvider;.*GuiceInjector;" +
-      ".*ControllerConfiguration;.*testonly.*"
+      ".*ControllerConfiguration;.*testonly.*",
+    ScoverageKeys.coverageMinimumStmtTotal := 90,
+    ScoverageKeys.coverageFailOnMinimum := true,
+    ScoverageKeys.coverageHighlighting := true,
   )
 
 lazy val testSettings: Seq[Def.Setting[_]] = Seq(


### PR DESCRIPTION
Summary of changes
* enable 90% minimum coverage check - build will fail if the coverage falls below this value