### PR TITLE
ESC-528 fix HTTP response code for NOT_FOUND case in backend

### DIFF
--- a/app/uk/gov/hmrc/eusubsidycompliance/controllers/UndertakingController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliance/controllers/UndertakingController.scala
@@ -16,6 +16,7 @@
 
 package uk.gov.hmrc.eusubsidycompliance.controllers
 
+import cats.data.EitherT
 import play.api.libs.json.{JsValue, Json}
 import play.api.mvc.{Action, AnyContent, ControllerComponents, Request}
 import uk.gov.hmrc.eusubsidycompliance.connectors.EisConnector
@@ -39,17 +40,13 @@ class UndertakingController @Inject() (
     extends BackendController(cc) {
 
   def retrieve(eori: String): Action[AnyContent] = authenticator.authorised { implicit request => _ =>
-    // TODO - use EitherT
-    eis
-      .retrieveUndertaking(EORI(eori))
-      .map {
-        _ match {
-          case Right(undertaking) => Ok(Json.toJson(undertaking))
-          case Left(ConnectorError(NOT_FOUND, _)) => NotFound
-          case Left(ConnectorError(NOT_ACCEPTABLE, _)) => NotAcceptable
-          case _ => InternalServerError
-        }
+    EitherT(eis.retrieveUndertaking(EORI(eori)))
+      .map(u => Ok(Json.toJson(u)))
+      .recover {
+        case ConnectorError(NOT_FOUND, _) => NotFound
+        case ConnectorError(NOT_ACCEPTABLE, _) => NotAcceptable
       }
+      .getOrElse(InternalServerError)
   }
 
   def create: Action[JsValue] = authenticator.authorisedWithJson(parse.json) { implicit request => _ =>

--- a/app/uk/gov/hmrc/eusubsidycompliance/controllers/UndertakingController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliance/controllers/UndertakingController.scala
@@ -39,12 +39,13 @@ class UndertakingController @Inject() (
     extends BackendController(cc) {
 
   def retrieve(eori: String): Action[AnyContent] = authenticator.authorised { implicit request => _ =>
+    // TODO - use EitherT
     eis
       .retrieveUndertaking(EORI(eori))
       .map {
         _ match {
           case Right(undertaking) => Ok(Json.toJson(undertaking))
-          case Left(ConnectorError(NOT_FOUND, _)) => BadRequest
+          case Left(ConnectorError(NOT_FOUND, _)) => NotFound
           case Left(ConnectorError(NOT_ACCEPTABLE, _)) => NotAcceptable
           case _ => InternalServerError
         }

--- a/test/uk/gov/hmrc/eusubsidycompliance/connectors/EisConnectorSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliance/connectors/EisConnectorSpec.scala
@@ -16,7 +16,6 @@
 
 package uk.gov.hmrc.eusubsidycompliance.connectors
 
-import cats.implicits.catsSyntaxOptionId
 import com.fasterxml.jackson.core.JsonParseException
 import com.github.tomakehurst.wiremock.client.WireMock._
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
@@ -25,9 +24,9 @@ import org.scalatest.wordspec.AnyWordSpecLike
 import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.Helpers.running
-import uk.gov.hmrc.eusubsidycompliance.models.{BusinessEntity, ConnectorError, SubsidyUpdate, UndertakingSubsidyAmendment}
 import uk.gov.hmrc.eusubsidycompliance.models.json.digital.EisBadResponseException
 import uk.gov.hmrc.eusubsidycompliance.models.types.{AmendmentType, EORI}
+import uk.gov.hmrc.eusubsidycompliance.models.{BusinessEntity, ConnectorError, SubsidyUpdate, UndertakingSubsidyAmendment}
 import uk.gov.hmrc.eusubsidycompliance.test.Fixtures._
 import uk.gov.hmrc.eusubsidycompliance.test.util.WiremockSupport
 import uk.gov.hmrc.http.{HeaderCarrier, UpstreamErrorResponse}

--- a/test/uk/gov/hmrc/eusubsidycompliance/controllers/UndertakingControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliance/controllers/UndertakingControllerSpec.scala
@@ -16,7 +16,6 @@
 
 package uk.gov.hmrc.eusubsidycompliance.controllers
 
-import cats.implicits.catsSyntaxOptionId
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatestplus.play.PlaySpec
@@ -25,15 +24,15 @@ import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.{Format, Json}
 import play.api.mvc.{ControllerComponents, Request, Result}
-import play.api.test.{FakeRequest, Helpers}
 import play.api.test.Helpers._
+import play.api.test.{FakeRequest, Helpers}
 import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.eusubsidycompliance.connectors.EisConnector
 import uk.gov.hmrc.eusubsidycompliance.controllers.actions.Auth
 import uk.gov.hmrc.eusubsidycompliance.models.types.AmendmentType.AmendmentType
-import uk.gov.hmrc.eusubsidycompliance.models.{BusinessEntity, ConnectorError, NilSubmissionDate, SubsidyRetrieve, SubsidyUpdate, Undertaking, UndertakingSubsidies}
 import uk.gov.hmrc.eusubsidycompliance.models.types.{AmendmentType, EORI, UndertakingRef}
-import uk.gov.hmrc.eusubsidycompliance.test.Fixtures.{businessEntity, date, eori, undertaking, undertakingReference, undertakingSubsidies}
+import uk.gov.hmrc.eusubsidycompliance.models._
+import uk.gov.hmrc.eusubsidycompliance.test.Fixtures._
 import uk.gov.hmrc.eusubsidycompliance.util.TimeProvider
 import uk.gov.hmrc.http.HeaderCarrier
 
@@ -55,11 +54,11 @@ class UndertakingControllerSpec extends PlaySpec with MockFactory with ScalaFutu
   private val mockEisConnector = mock[EisConnector]
   private val mockTimeProvider = mock[TimeProvider]
 
-  "UnderTakingController" when {
+  "UndertakingController" when {
 
     "retrieve is called" should {
 
-      "Happy path" in {
+      "return a successful response for a valid request where the undertaking exists" in {
 
         val app = configuredAppInstance
 
@@ -73,7 +72,7 @@ class UndertakingControllerSpec extends PlaySpec with MockFactory with ScalaFutu
 
       }
 
-      "Connector error with 404" in {
+      "return a HTTP 404 if the connector returns an 404 error" in {
         val app = configuredAppInstance
 
         givenRetrieveRetrieveUndertaking(Left(ConnectorError(NOT_FOUND, "not found")))
@@ -81,12 +80,11 @@ class UndertakingControllerSpec extends PlaySpec with MockFactory with ScalaFutu
           val request = FakeRequest(GET, routes.UndertakingController.retrieve(eori).url)
           val result = route(app, request).value
 
-          status(result) mustBe Status.BAD_REQUEST
-
+          status(result) mustBe NOT_FOUND
         }
-
       }
-      "Connector error with 406" in {
+
+      "return a HTTP 406 if the connector returns an 404 error" in {
         val app = configuredAppInstance
 
         givenRetrieveRetrieveUndertaking(Left(ConnectorError(NOT_ACCEPTABLE, "eori not in EMTP")))
@@ -94,8 +92,7 @@ class UndertakingControllerSpec extends PlaySpec with MockFactory with ScalaFutu
           val request = FakeRequest(GET, routes.UndertakingController.retrieve(eori).url)
           val result = route(app, request).value
 
-          status(result) mustBe Status.NOT_ACCEPTABLE
-
+          status(result) mustBe NOT_ACCEPTABLE
         }
 
       }

--- a/test/uk/gov/hmrc/eusubsidycompliance/controllers/UndertakingControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliance/controllers/UndertakingControllerSpec.scala
@@ -94,7 +94,19 @@ class UndertakingControllerSpec extends PlaySpec with MockFactory with ScalaFutu
 
           status(result) mustBe NOT_ACCEPTABLE
         }
+      }
 
+      "return a HTTP 500 if the connector returns any other error" in {
+        val app = configuredAppInstance
+
+        givenRetrieveRetrieveUndertaking(Left(ConnectorError(INTERNAL_SERVER_ERROR, "ruh roh!")))
+        running(app) {
+          val request = FakeRequest(GET, routes.UndertakingController.retrieve(eori).url)
+          val result = route(app, request).value
+
+          status(result) mustBe INTERNAL_SERVER_ERROR
+        }
+        
       }
     }
 

--- a/test/uk/gov/hmrc/eusubsidycompliance/controllers/UndertakingControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliance/controllers/UndertakingControllerSpec.scala
@@ -106,7 +106,7 @@ class UndertakingControllerSpec extends PlaySpec with MockFactory with ScalaFutu
 
           status(result) mustBe INTERNAL_SERVER_ERROR
         }
-        
+
       }
     }
 


### PR DESCRIPTION
Summary of changes
* fix HTTP response code for the NOT_FOUND response - should be 404 not 400
* use EitherT in EIS connector response handling