### PR TITLE
ESC-551 align HmrcSubsidy model to v3.0 of the SCP09 spec

### DIFF
--- a/app/uk/gov/hmrc/eusubsidycompliance/models/HmrcSubsidy.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliance/models/HmrcSubsidy.scala
@@ -28,7 +28,8 @@ case class HmrcSubsidy(
   declarantEORI: EORI, // n.b. SCP09 uses looser validation but will stick with ours
   consigneeEORI: EORI,
   taxType: Option[TaxType],
-  amount: Option[SubsidyAmount],
+  hmrcSubsidyAmtGBP: Option[SubsidyAmount],
+  hmrcSubsidyAmtEUR: Option[SubsidyAmount],
   tradersOwnRefUCR: Option[TraderRef]
 )
 

--- a/test/uk/gov/hmrc/eusubsidycompliance/connectors/EisConnectorSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliance/connectors/EisConnectorSpec.scala
@@ -211,7 +211,8 @@ class EisConnectorSpec
          |       "declarantEORI": "$eori",
          |       "consigneeEORI": "$eori",
          |       "taxType": "$taxType",
-         |       "amount": $subsidyAmount,
+         |       "hmrcSubsidyAmtGBP": $subsidyAmount,
+         |       "hmrcSubsidyAmtEUR": $subsidyAmount,
          |       "tradersOwnRefUCR": "$traderRef"
          |     } ]
          |   }

--- a/test/uk/gov/hmrc/eusubsidycompliance/test/Fixtures.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliance/test/Fixtures.scala
@@ -57,7 +57,8 @@ object Fixtures {
     declarantEORI = eori,
     consigneeEORI = eori,
     taxType = Some(taxType),
-    amount = Some(subsidyAmount),
+    hmrcSubsidyAmtGBP = Some(subsidyAmount),
+    hmrcSubsidyAmtEUR = Some(subsidyAmount),
     tradersOwnRefUCR = Some(traderRef)
   )
 


### PR DESCRIPTION
Summary of changes
* replace HMRC subsidy `amount` field with new currency specific amount fields introduced in the latest version of the `SCP09` specification