### PR TITLE
ESC-615 introduce separate retrieve and create models for Undertakings

### DIFF
--- a/app/uk/gov/hmrc/eusubsidycompliance/connectors/EisConnector.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliance/connectors/EisConnector.scala
@@ -53,12 +53,12 @@ class EisConnector @Inject() (
 
   def retrieveUndertaking(
     eori: EORI
-  )(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Either[ConnectorError, Undertaking]] = {
+  )(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Either[ConnectorError, UndertakingRetrieve]] = {
     import uk.gov.hmrc.eusubsidycompliance.models.json.digital.retrieveUndertakingResponseReads
 
     val eisTokenKey = "eis.token.scp04"
     val retrieveUndertakingRequest = RetrieveUndertakingAPIRequest(eori)
-    desPost[RetrieveUndertakingAPIRequest, Undertaking](
+    desPost[RetrieveUndertakingAPIRequest, UndertakingRetrieve](
       s"$eisURL/$retrieveUndertakingPath",
       retrieveUndertakingRequest,
       eisTokenKey
@@ -76,7 +76,7 @@ class EisConnector @Inject() (
   }
 
   def createUndertaking(
-    undertaking: Undertaking
+    undertaking: UndertakingCreate
   )(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[UndertakingRef] = {
 
     import uk.gov.hmrc.eusubsidycompliance.models.json.digital.{createUndertakingResponseReads}
@@ -90,7 +90,7 @@ class EisConnector @Inject() (
   }
 
   def updateUndertaking(
-    undertaking: Undertaking,
+    undertaking: UndertakingRetrieve,
     amendmentType: EisAmendmentType
   )(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[UndertakingRef] = {
 

--- a/app/uk/gov/hmrc/eusubsidycompliance/controllers/UndertakingController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliance/controllers/UndertakingController.scala
@@ -49,7 +49,7 @@ class UndertakingController @Inject() (
   }
 
   def create: Action[JsValue] = authenticator.authorisedWithJson(parse.json) { implicit request => _ =>
-    withJsonBody[Undertaking] { undertaking: Undertaking =>
+    withJsonBody[UndertakingCreate] { undertaking: UndertakingCreate =>
       for {
         ref <- eis.createUndertaking(undertaking)
         _ <- eis.upsertSubsidyUsage(SubsidyUpdate(ref, NilSubmissionDate(timeProvider.today)))
@@ -58,13 +58,13 @@ class UndertakingController @Inject() (
   }
 
   def updateUndertaking: Action[JsValue] = authenticator.authorisedWithJson(parse.json) { implicit request => _ =>
-    withJsonBody[Undertaking] { undertaking: Undertaking =>
+    withJsonBody[UndertakingRetrieve] { undertaking: UndertakingRetrieve =>
       eis.updateUndertaking(undertaking, EisAmendmentType.A).map(ref => Ok(Json.toJson(ref)))
     }
   }
 
   def disableUndertaking: Action[JsValue] = authenticator.authorisedWithJson(parse.json) { implicit request => _ =>
-    withJsonBody[Undertaking] { undertaking: Undertaking =>
+    withJsonBody[UndertakingRetrieve] { undertaking: UndertakingRetrieve =>
       eis.updateUndertaking(undertaking, EisAmendmentType.D).map(ref => Ok(Json.toJson(ref)))
     }
   }

--- a/app/uk/gov/hmrc/eusubsidycompliance/models/Undertaking.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliance/models/Undertaking.scala
@@ -22,7 +22,19 @@ import java.time.LocalDate
 import uk.gov.hmrc.eusubsidycompliance.models.types._
 import uk.gov.hmrc.eusubsidycompliance.models.types.Sector.Sector
 
-case class Undertaking(
+case class UndertakingCreate(
+  name: UndertakingName,
+  industrySector: Sector,
+  industrySectorLimit: Option[IndustrySectorLimit],
+  lastSubsidyUsageUpdt: Option[LocalDate],
+  undertakingBusinessEntity: List[BusinessEntity]
+)
+
+object UndertakingCreate {
+  implicit val undertakingFormat: OFormat[UndertakingCreate] = Json.format[UndertakingCreate]
+}
+
+case class UndertakingRetrieve(
   reference: Option[UndertakingRef],
   name: UndertakingName,
   industrySector: Sector,
@@ -31,6 +43,6 @@ case class Undertaking(
   undertakingBusinessEntity: List[BusinessEntity]
 )
 
-object Undertaking {
-  implicit val undertakingFormat: OFormat[Undertaking] = Json.format[Undertaking]
+object UndertakingRetrieve {
+  implicit val undertakingFormat: OFormat[UndertakingRetrieve] = Json.format[UndertakingRetrieve]
 }

--- a/app/uk/gov/hmrc/eusubsidycompliance/models/json/digital/package.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliance/models/json/digital/package.scala
@@ -21,7 +21,7 @@ import play.api.libs.json._
 import uk.gov.hmrc.eusubsidycompliance.models.json.eis.Params
 import uk.gov.hmrc.eusubsidycompliance.models.types.Sector.Sector
 import uk.gov.hmrc.eusubsidycompliance.models.types.{IndustrySectorLimit, UndertakingName, UndertakingRef}
-import uk.gov.hmrc.eusubsidycompliance.models.{BusinessEntity, Undertaking}
+import uk.gov.hmrc.eusubsidycompliance.models.{BusinessEntity, UndertakingRetrieve}
 
 import java.time.format.DateTimeFormatter
 import java.time.{Clock, Instant, LocalDate, LocalDateTime, ZoneOffset, ZonedDateTime}
@@ -45,12 +45,12 @@ package object digital {
       formatter.format(in.toInstant(ZoneOffset.UTC).minusNanos(in.getNano))
   }
 
-  implicit val retrieveUndertakingResponseReads: Reads[Undertaking] =
-    readResponseFor[Undertaking]("retrieveUndertakingResponse") { json =>
+  implicit val retrieveUndertakingResponseReads: Reads[UndertakingRetrieve] =
+    readResponseFor[UndertakingRetrieve]("retrieveUndertakingResponse") { json =>
       val responseDetail = json \ "retrieveUndertakingResponse" \ "responseDetail"
 
       JsSuccess(
-        Undertaking(
+        UndertakingRetrieve(
           reference = (responseDetail \ "undertakingReference").asOpt[String].map(UndertakingRef(_)),
           name = (responseDetail \ "undertakingName").as[UndertakingName],
           industrySector = (responseDetail \ "industrySector").as[Sector],

--- a/app/uk/gov/hmrc/eusubsidycompliance/models/undertakingOperationsFormat/CreateUndertakingApiRequest.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliance/models/undertakingOperationsFormat/CreateUndertakingApiRequest.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.eusubsidycompliance.models.undertakingOperationsFormat
 
 import play.api.libs.json.{Json, Writes}
-import uk.gov.hmrc.eusubsidycompliance.models.{BusinessEntity, Undertaking}
+import uk.gov.hmrc.eusubsidycompliance.models.{BusinessEntity, UndertakingCreate}
 import uk.gov.hmrc.eusubsidycompliance.models.json.eis.RequestCommon
 import uk.gov.hmrc.eusubsidycompliance.models.types.Sector.Sector
 import uk.gov.hmrc.eusubsidycompliance.models.types.UndertakingName
@@ -28,11 +28,10 @@ import java.time.format.DateTimeFormatter
 final case class CreateUndertakingApiRequest(createUndertakingRequest: CreateUndertakingRequest)
 object CreateUndertakingApiRequest {
 
-  def apply(undertaking: Undertaking): CreateUndertakingApiRequest = {
+  def apply(undertaking: UndertakingCreate): CreateUndertakingApiRequest = {
     val lead: BusinessEntity =
       undertaking.undertakingBusinessEntity
-        .filter(_.leadEORI)
-        .headOption
+        .find(_.leadEORI)
         .fold(sys.error("Lead missing in undertaking"))(identity)
     CreateUndertakingApiRequest(
       CreateUndertakingRequest(

--- a/app/uk/gov/hmrc/eusubsidycompliance/models/undertakingOperationsFormat/UpdateUndertakingApiRequest.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliance/models/undertakingOperationsFormat/UpdateUndertakingApiRequest.scala
@@ -17,11 +17,11 @@
 package uk.gov.hmrc.eusubsidycompliance.models.undertakingOperationsFormat
 
 import play.api.libs.json.{Json, Writes}
-import uk.gov.hmrc.eusubsidycompliance.models.Undertaking
+import uk.gov.hmrc.eusubsidycompliance.models.UndertakingRetrieve
 import uk.gov.hmrc.eusubsidycompliance.models.json.eis.RequestCommon
-import uk.gov.hmrc.eusubsidycompliance.models.types.{EisAmendmentType, UndertakingName, UndertakingRef}
 import uk.gov.hmrc.eusubsidycompliance.models.types.EisAmendmentType.EisAmendmentType
 import uk.gov.hmrc.eusubsidycompliance.models.types.Sector.Sector
+import uk.gov.hmrc.eusubsidycompliance.models.types.{UndertakingName, UndertakingRef}
 
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
@@ -31,7 +31,7 @@ final case class UpdateUndertakingApiRequest(updateUndertakingRequest: UpdateUnd
 object UpdateUndertakingApiRequest {
   implicit val writes: Writes[UpdateUndertakingApiRequest] = Json.writes
 
-  def apply(undertaking: Undertaking, amendmentType: EisAmendmentType): UpdateUndertakingApiRequest =
+  def apply(undertaking: UndertakingRetrieve, amendmentType: EisAmendmentType): UpdateUndertakingApiRequest =
     UpdateUndertakingApiRequest(
       UpdateUndertakingRequest(
         requestDetail = UpdateUndertakingRequestDetail(

--- a/test/uk/gov/hmrc/eusubsidycompliance/connectors/EisConnectorSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliance/connectors/EisConnectorSpec.scala
@@ -177,7 +177,7 @@ class EisConnectorSpec
         )
 
         testWithRunningApp { underTest =>
-          underTest.createUndertaking(undertaking).futureValue mustBe undertakingReference
+          underTest.createUndertaking(undertakingCreate).futureValue mustBe undertakingReference
         }
       }
     }

--- a/test/uk/gov/hmrc/eusubsidycompliance/connectors/EisConnectorSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliance/connectors/EisConnectorSpec.scala
@@ -25,7 +25,6 @@ import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.Helpers.running
 import uk.gov.hmrc.eusubsidycompliance.models.json.digital.EisBadResponseException
-import uk.gov.hmrc.eusubsidycompliance.models.types.EisAmendmentType.EisAmendmentType
 import uk.gov.hmrc.eusubsidycompliance.models.types.{AmendmentType, EORI, EisAmendmentType}
 import uk.gov.hmrc.eusubsidycompliance.models.{BusinessEntity, ConnectorError, SubsidyUpdate, UndertakingSubsidyAmendment}
 import uk.gov.hmrc.eusubsidycompliance.test.Fixtures._

--- a/test/uk/gov/hmrc/eusubsidycompliance/controllers/UndertakingControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliance/controllers/UndertakingControllerSpec.scala
@@ -112,7 +112,7 @@ class UndertakingControllerSpec extends PlaySpec with MockFactory with ScalaFutu
     }
 
     "updateUndertaking is called" should {
-      implicit val format: Format[Undertaking] = Json.format[Undertaking]
+      implicit val format: Format[UndertakingRetrieve] = Json.format[UndertakingRetrieve]
 
       "Happy path" in {
         val app = configuredAppInstance
@@ -184,7 +184,6 @@ class UndertakingControllerSpec extends PlaySpec with MockFactory with ScalaFutu
     }
 
     "create undertaking is called" should {
-      implicit val format: Format[Undertaking] = Json.format[Undertaking]
 
       "return a valid response for a successful to create undertaking" in {
 
@@ -305,8 +304,8 @@ class UndertakingControllerSpec extends PlaySpec with MockFactory with ScalaFutu
     }
 
     "disable undertaking is called" should {
-      implicit val format: Format[Undertaking] = Json.format[Undertaking]
-      "Happy path" in {
+
+      "return OK for a successful request" in {
         val app = configuredAppInstance
 
         givenUpdateUndertaking(Future.successful(undertakingReference), EisAmendmentType.D)
@@ -343,8 +342,8 @@ class UndertakingControllerSpec extends PlaySpec with MockFactory with ScalaFutu
 
   private def givenCreateUndertakingReturns(res: Future[UndertakingRef]): Unit =
     (mockEisConnector
-      .createUndertaking(_: Undertaking)(_: HeaderCarrier, _: ExecutionContext))
-      .expects(undertaking, *, *)
+      .createUndertaking(_: UndertakingCreate)(_: HeaderCarrier, _: ExecutionContext))
+      .expects(undertakingCreate, *, *)
       .returning(res)
 
   private def givenUpdateSubsidy(res: Future[Unit]): Unit =
@@ -356,7 +355,7 @@ class UndertakingControllerSpec extends PlaySpec with MockFactory with ScalaFutu
   private def returningFixedDate(fixedDate: LocalDate): Unit =
     (mockTimeProvider.today _).expects().returning(fixedDate)
 
-  private def givenRetrieveRetrieveUndertaking(res: Either[ConnectorError, Undertaking]): Unit =
+  private def givenRetrieveRetrieveUndertaking(res: Either[ConnectorError, UndertakingRetrieve]): Unit =
     (mockEisConnector
       .retrieveUndertaking(_: EORI)(_: HeaderCarrier, _: ExecutionContext))
       .expects(eori, *, *)
@@ -364,7 +363,7 @@ class UndertakingControllerSpec extends PlaySpec with MockFactory with ScalaFutu
 
   private def givenUpdateUndertaking(res: Future[UndertakingRef], eisAmendmentType: EisAmendmentType): Unit =
     (mockEisConnector
-      .updateUndertaking(_: Undertaking, _: EisAmendmentType)(_: HeaderCarrier, _: ExecutionContext))
+      .updateUndertaking(_: UndertakingRetrieve, _: EisAmendmentType)(_: HeaderCarrier, _: ExecutionContext))
       .expects(undertaking, eisAmendmentType, *, *)
       .returning(res)
 

--- a/test/uk/gov/hmrc/eusubsidycompliance/test/Fixtures.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliance/test/Fixtures.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.eusubsidycompliance.test
 
-import uk.gov.hmrc.eusubsidycompliance.models.{BusinessEntity, HmrcSubsidy, NonHmrcSubsidy, Undertaking, UndertakingSubsidies}
+import uk.gov.hmrc.eusubsidycompliance.models.{BusinessEntity, HmrcSubsidy, NonHmrcSubsidy, UndertakingCreate, UndertakingRetrieve, UndertakingSubsidies}
 import uk.gov.hmrc.eusubsidycompliance.models.types.{DeclarationID, EORI, IndustrySectorLimit, Sector, SubsidyAmount, SubsidyRef, TaxType, TraderRef, UndertakingName, UndertakingRef}
 
 import java.time.{Instant, ZoneId}
@@ -33,7 +33,15 @@ object Fixtures {
   val date = fixedInstant.atZone(ZoneId.of("Europe/London")).toLocalDate
   val subsidyAmount = SubsidyAmount(BigDecimal(123.45))
 
-  val undertaking = Undertaking(
+  val undertakingCreate = UndertakingCreate(
+    undertakingName,
+    sector,
+    Some(industrySectorLimit),
+    Some(date),
+    List(BusinessEntity(eori, leadEORI = true))
+  )
+
+  val undertaking = UndertakingRetrieve(
     Some(undertakingReference),
     undertakingName,
     sector,


### PR DESCRIPTION
Summary of changes
* introduce separate retrieve and create models for Undertaking to bring the backend into line with the corresponding changes made to the frontend 
* updated tests
* fixed compiler warning