### PR TITLE
ESC-617 Fetch EUR to GBP exchange rates from Europa API

### DIFF
--- a/app/uk/gov/hmrc/eusubsidycompliance/connectors/EuropaConnector.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliance/connectors/EuropaConnector.scala
@@ -53,7 +53,7 @@ class EuropaConnector @Inject() (
         "startPeriod" -> yearMonthFormatter.format(date),
         "endPeriod" -> yearMonthFormatter.format(date),
         "detail" -> "dataonly",
-        "lastNObservations" -> s"2"
+        "lastNObservations" -> "2"
       )
     )
 

--- a/app/uk/gov/hmrc/eusubsidycompliance/connectors/EuropaConnector.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliance/connectors/EuropaConnector.scala
@@ -42,8 +42,10 @@ class EuropaConnector @Inject() (
   // Daily spot rate for GBP to EUR - see https://sdw-wsrest.ecb.europa.eu/help/ for API docs.
   private val ResourcePath = "service/data/EXR/D.GBP.EUR.SP00.A"
 
-  // TODO - review naming and docs
-  def retrieveExchangeRate(date: LocalDate)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[ExchangeRate] =
+  // We request the last two rates for the month of the specified date. The penultimate rate will be the rate that
+  // applies which corresponds to the first of the two rates returned.
+  // The europa response parsing takes care of selecting this rate. See ExchangeRate companion object.
+  def retrieveApplicableExchangeRate(date: LocalDate)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[ExchangeRate] =
     client.GET[ExchangeRate](
       url = s"$europaBasePath/$ResourcePath",
       headers = Seq("Accept" -> "application/vnd.sdmx.data+json;version=1.0.0-wd"),
@@ -51,7 +53,7 @@ class EuropaConnector @Inject() (
         "startPeriod" -> yearMonthFormatter.format(date),
         "endPeriod" -> yearMonthFormatter.format(date),
         "detail" -> "dataonly",
-        "lastNObservations" -> s"2" // Fetch the last 2 observations and return the first which corresponds to the penultimate value for the month
+        "lastNObservations" -> s"2"
       )
     )
 

--- a/app/uk/gov/hmrc/eusubsidycompliance/connectors/EuropaConnector.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliance/connectors/EuropaConnector.scala
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.eusubsidycompliance.connectors
+
+import org.slf4j.LoggerFactory
+import play.api.libs.json.{JsResult, JsSuccess, JsValue, Reads}
+import uk.gov.hmrc.http.{HeaderCarrier, HttpClient}
+import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
+
+import java.time.LocalDate
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class EuropaConnector @Inject() (
+  val client: HttpClient,
+  val servicesConfig: ServicesConfig
+) {
+
+  private val logger = LoggerFactory.getLogger(this.getClass)
+
+  // TODO - add this to config
+//  private lazy val europaBasePath = servicesConfig.baseUrl("europa")
+
+  // TODO - this should return an Either
+  def retrieveExchangeRate(
+    // TODO - introduce currency code type - or remove these params for now?
+    from: String,
+    to: String,
+    date: LocalDate
+  )(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[EuropaResponse] = {
+    val url = "https://sdw-wsrest.ecb.europa.eu/service/data/EXR/D.GBP.EUR.SP00.A"
+    val result = client.GET[EuropaResponse](
+      url = url,
+      headers = Seq("Accept" -> "application/vnd.sdmx.data+json;version=1.0.0-wd"),
+      queryParams = Seq(
+        // TODO - use date parameter
+        "startPeriod" -> "2022-01-03",
+        "endPeriod" -> "2022-01-03",
+        "detail" -> "dataonly",
+        "lastNObservations" -> "1"
+      )
+    )
+    result.map(r => "Got result: $r")
+    result
+  }
+
+}
+
+object EuropaResponse {
+
+  implicit val europaResponseReads: Reads[EuropaResponse] = (json: JsValue) => {
+    // Extract the rate from the JSON response which has the following format.
+    //
+    //     "dataSets": [
+    //        {
+    //            "action": "Replace",
+    //            "validFrom": "2022-06-22T12:32:42.940+02:00",
+    //            "series": {
+    //                "0:0:0:0:0": {
+    //                    "observations": {
+    //                        "0": [
+    //                            0.84135
+    //                        ]
+    //                    }
+    //                }
+    //            }
+    //        }
+    //    ],
+    //
+    // We only ever expect a single rate to be returned in the format shown above.
+    val rate = ((json \ "dataSets") (0) \ "series" \ "0:0:0:0:0" \ "observations" \ "0") (0).as[BigDecimal]
+
+    JsSuccess(EuropaResponse("EUR", "GBP", rate))
+  }
+
+}
+
+case class EuropaResponse(from: String, to: String, rate: BigDecimal)

--- a/app/uk/gov/hmrc/eusubsidycompliance/connectors/EuropaConnector.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliance/connectors/EuropaConnector.scala
@@ -37,7 +37,7 @@ class EuropaConnector @Inject() (
 
   private lazy val europaBasePath = servicesConfig.baseUrl("europa")
 
-  private val yearMonthFormatter = DateTimeFormatter.ofPattern("YYYY-MM")
+  private val yearMonthFormatter = DateTimeFormatter.ofPattern("u-MM")
 
   // Daily spot rate for GBP to EUR - see https://sdw-wsrest.ecb.europa.eu/help/ for API docs.
   private val ResourcePath = "service/data/EXR/D.GBP.EUR.SP00.A"

--- a/app/uk/gov/hmrc/eusubsidycompliance/controllers/ExchangeRateController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliance/controllers/ExchangeRateController.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.eusubsidycompliance.controllers
+
+import play.api.libs.json.Json
+import play.api.mvc.{Action, AnyContent, ControllerComponents}
+import uk.gov.hmrc.eusubsidycompliance.controllers.actions.Auth
+import uk.gov.hmrc.eusubsidycompliance.services.ExchangeRateService
+import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
+
+import java.time.LocalDate
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.ExecutionContext
+
+@Singleton
+class ExchangeRateController @Inject() (
+  cc: ControllerComponents,
+  authenticator: Auth,
+  service: ExchangeRateService
+)(implicit ec: ExecutionContext) extends BackendController(cc) {
+
+  // TODO - review error handling
+  def getExchangeRate(dateString: String): Action[AnyContent] = authenticator.authorised { implicit request => _ =>
+    // TODO - handle errors - also are there play bindings for LocalDate already?
+    //      - return bad request for malformed date
+    val parsedDate = LocalDate.parse(dateString)
+    service.getExchangeRate(parsedDate)
+      .map(r => Ok(Json.toJson(r)))
+  }
+
+}

--- a/app/uk/gov/hmrc/eusubsidycompliance/models/ExchangeRate.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliance/models/ExchangeRate.scala
@@ -46,7 +46,7 @@ object ExchangeRate {
 
     // For now we can hardcode the from and to currencies since we only ever request the GBP to EUR rate.
     // TODO - do we even need to include the from and to values since they are constant?
-    JsSuccess(ExchangeRate("GBP", "EUR", rate))
+    JsSuccess(ExchangeRate("EUR", "GBP", rate))
   }
 
   implicit val exchangeRateWrites: Writes[ExchangeRate] = Json.writes[ExchangeRate]

--- a/app/uk/gov/hmrc/eusubsidycompliance/models/ExchangeRate.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliance/models/ExchangeRate.scala
@@ -37,6 +37,9 @@ object ExchangeRate {
     //                    "observations": {
     //                        "0": [
     //                            0.84135
+    //                        ],
+    //                        "1": [
+    //                            0.90132
     //                        ]
     //                    }
     //                }
@@ -44,7 +47,8 @@ object ExchangeRate {
     //        }
     //    ],
     //
-    // We only ever expect a single rate to be returned in the format shown above.
+    // Note - we request the last 2 rate observations for the month and return the penultimate value for that month
+    //        in order to align with the Europa exchange rate converter (see https://ec.europa.eu/info/funding-tenders/procedures-guidelines-tenders/information-contractors-and-beneficiaries/exchange-rate-inforeuro_en)
     val rate = ((json \ "dataSets") (0) \ "series" \ "0:0:0:0:0" \ "observations" \ "0") (0).as[BigDecimal]
 
     JsSuccess(ExchangeRate(rate))

--- a/app/uk/gov/hmrc/eusubsidycompliance/models/ExchangeRate.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliance/models/ExchangeRate.scala
@@ -22,6 +22,9 @@ case class ExchangeRate(from: String, to: String, rate: BigDecimal)
 
 object ExchangeRate {
 
+  // Convenience constructor for the default case
+  def apply(rate: BigDecimal): ExchangeRate = ExchangeRate("EUR", "GBP", rate)
+
   implicit val europaResponseReads: Reads[ExchangeRate] = (json: JsValue) => {
     // Extract the rate from the JSON response which has the following format.
     //
@@ -44,9 +47,7 @@ object ExchangeRate {
     // We only ever expect a single rate to be returned in the format shown above.
     val rate = ((json \ "dataSets") (0) \ "series" \ "0:0:0:0:0" \ "observations" \ "0") (0).as[BigDecimal]
 
-    // For now we can hardcode the from and to currencies since we only ever request the GBP to EUR rate.
-    // TODO - do we even need to include the from and to values since they are constant?
-    JsSuccess(ExchangeRate("EUR", "GBP", rate))
+    JsSuccess(ExchangeRate(rate))
   }
 
   implicit val exchangeRateWrites: Writes[ExchangeRate] = Json.writes[ExchangeRate]

--- a/app/uk/gov/hmrc/eusubsidycompliance/models/ExchangeRate.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliance/models/ExchangeRate.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.eusubsidycompliance.models
 
-import play.api.libs.json.{JsSuccess, JsValue, Reads}
+import play.api.libs.json.{JsSuccess, JsValue, Json, Reads, Writes}
 
 case class ExchangeRate(from: String, to: String, rate: BigDecimal)
 
@@ -48,6 +48,8 @@ object ExchangeRate {
     // TODO - do we even need to include the from and to values since they are constant?
     JsSuccess(ExchangeRate("GBP", "EUR", rate))
   }
+
+  implicit val exchangeRateWrites: Writes[ExchangeRate] = Json.writes[ExchangeRate]
 
 }
 

--- a/app/uk/gov/hmrc/eusubsidycompliance/models/ExchangeRate.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliance/models/ExchangeRate.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.eusubsidycompliance.models
+
+import play.api.libs.json.{JsSuccess, JsValue, Reads}
+
+case class ExchangeRate(from: String, to: String, rate: BigDecimal)
+
+object ExchangeRate {
+
+  implicit val europaResponseReads: Reads[ExchangeRate] = (json: JsValue) => {
+    // Extract the rate from the JSON response which has the following format.
+    //
+    //     "dataSets": [
+    //        {
+    //            "action": "Replace",
+    //            "validFrom": "2022-06-22T12:32:42.940+02:00",
+    //            "series": {
+    //                "0:0:0:0:0": {
+    //                    "observations": {
+    //                        "0": [
+    //                            0.84135
+    //                        ]
+    //                    }
+    //                }
+    //            }
+    //        }
+    //    ],
+    //
+    // We only ever expect a single rate to be returned in the format shown above.
+    val rate = ((json \ "dataSets") (0) \ "series" \ "0:0:0:0:0" \ "observations" \ "0") (0).as[BigDecimal]
+
+    // For now we can hardcode the from and to currencies since we only ever request the GBP to EUR rate.
+    // TODO - do we even need to include the from and to values since they are constant?
+    JsSuccess(ExchangeRate("GBP", "EUR", rate))
+  }
+
+}
+

--- a/app/uk/gov/hmrc/eusubsidycompliance/services/ExchangeRateService.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliance/services/ExchangeRateService.scala
@@ -34,7 +34,7 @@ class ExchangeRateService @Inject() (
       dateForExchangeRate(date),
     )
 
-  // The exchange rate for a given month is taken from the end of the preceding month.
+  // The exchange rate for a given month is the penultimate value of the preceding month.
   private def dateForExchangeRate(date: LocalDate): LocalDate =
     date
       .withDayOfMonth(1)

--- a/app/uk/gov/hmrc/eusubsidycompliance/services/ExchangeRateService.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliance/services/ExchangeRateService.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.eusubsidycompliance.services
+
+import uk.gov.hmrc.eusubsidycompliance.connectors.EuropaConnector
+import uk.gov.hmrc.eusubsidycompliance.models.ExchangeRate
+import uk.gov.hmrc.http.HeaderCarrier
+
+import java.time.LocalDate
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class ExchangeRateService @Inject() (
+  europaConnector: EuropaConnector
+)(implicit ec: ExecutionContext) {
+
+  def getExchangeRate(date: LocalDate)(implicit hc: HeaderCarrier): Future[ExchangeRate] =
+    europaConnector.retrieveExchangeRate(dateForExchangeRate(date))
+
+  // The exchange rate for a given month is the value of the rate on the penultimate day of the preceding month.
+  // For example the rate to apply for the whole of April 2022 will be the published rate for 30th March 2022.
+  private def dateForExchangeRate(date: LocalDate): LocalDate = {
+    val previousMonth = date.minusMonths(1)
+    val penultimateDay = previousMonth.lengthOfMonth() - 1
+
+    previousMonth.withDayOfMonth(penultimateDay)
+  }
+
+}

--- a/app/uk/gov/hmrc/eusubsidycompliance/services/ExchangeRateService.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliance/services/ExchangeRateService.scala
@@ -30,7 +30,7 @@ class ExchangeRateService @Inject() (
 )(implicit ec: ExecutionContext) {
 
   def getExchangeRate(date: LocalDate)(implicit hc: HeaderCarrier): Future[ExchangeRate] =
-    europaConnector.retrieveExchangeRate(
+    europaConnector.retrieveApplicableExchangeRate(
       dateForExchangeRate(date),
     )
 

--- a/app/uk/gov/hmrc/eusubsidycompliance/services/ExchangeRateService.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliance/services/ExchangeRateService.scala
@@ -30,15 +30,14 @@ class ExchangeRateService @Inject() (
 )(implicit ec: ExecutionContext) {
 
   def getExchangeRate(date: LocalDate)(implicit hc: HeaderCarrier): Future[ExchangeRate] =
-    europaConnector.retrieveExchangeRate(dateForExchangeRate(date))
+    europaConnector.retrieveExchangeRate(
+      dateForExchangeRate(date),
+    )
 
-  // The exchange rate for a given month is the value of the rate on the penultimate day of the preceding month.
-  // For example the rate to apply for the whole of April 2022 will be the published rate for 30th March 2022.
-  private def dateForExchangeRate(date: LocalDate): LocalDate = {
-    val previousMonth = date.minusMonths(1)
-    val penultimateDay = previousMonth.lengthOfMonth() - 1
-
-    previousMonth.withDayOfMonth(penultimateDay)
-  }
+  // The exchange rate for a given month is taken from the end of the preceding month.
+  private def dateForExchangeRate(date: LocalDate): LocalDate =
+    date
+      .withDayOfMonth(1)
+      .minusMonths(1)
 
 }

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -10,6 +10,8 @@ POST       /undertaking/member/remove/:undertakingRef       uk.gov.hmrc.eusubsid
 
 POST       /subsidy/update                                  uk.gov.hmrc.eusubsidycompliance.controllers.UndertakingController.updateSubsidy()
 
-POST       /undertaking/disable                                 uk.gov.hmrc.eusubsidycompliance.controllers.UndertakingController.disableUndertaking()
+POST       /undertaking/disable                             uk.gov.hmrc.eusubsidycompliance.controllers.UndertakingController.disableUndertaking()
 
 POST       /subsidy/retrieve                                uk.gov.hmrc.eusubsidycompliance.controllers.UndertakingController.retrieveSubsidies()
+
+GET        /exchangerate/:date                              uk.gov.hmrc.eusubsidycompliance.controllers.ExchangeRateController.getExchangeRate(date)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -147,6 +147,11 @@ microservice {
       environment = "live"
     }
 
+    europa {
+      host = localhost
+      port = 9095
+    }
+
   }
 }
 

--- a/test/uk/gov/hmrc/eusubsidycompliance/connectors/EuropaConnectorSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliance/connectors/EuropaConnectorSpec.scala
@@ -198,7 +198,6 @@ class EuropaConnectorSpec extends AnyWordSpecLike
   private def configuredApplication: Application =
     new GuiceApplicationBuilder()
       .configure(
-        "microservice.services.europa.protocol" -> "http",
         "microservice.services.europa.host" -> "localhost",
         "microservice.services.europa.port" -> server.port()
       ).build()

--- a/test/uk/gov/hmrc/eusubsidycompliance/connectors/EuropaConnectorSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliance/connectors/EuropaConnectorSpec.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.eusubsidycompliance.connectors
+
+import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.test.Helpers.running
+import uk.gov.hmrc.http.HeaderCarrier
+
+import java.time.LocalDate
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class EuropaConnectorSpec extends AnyWordSpecLike
+  with Matchers
+  with ScalaFutures
+  with IntegrationPatience {
+
+  implicit private val hc: HeaderCarrier = HeaderCarrier()
+
+  "EuropaConnector" when {
+
+    // TODO - initial placeholder to verify that we can hit the real API and parse the response
+    "a request is made" in {
+
+      testWithRunningApp { underTest =>
+        val result = underTest.retrieveExchangeRate("GBP", "EUR", LocalDate.of(2022, 4, 29))
+        result.futureValue mustBe EuropaResponse("EUR", "GBP", BigDecimal(0.84135))
+      }
+
+
+    }
+
+  }
+
+  private def configuredApplication: Application =
+    new GuiceApplicationBuilder()
+      .configure(
+        // TODO - configure this to point to wiremock
+        "microservice.services.eis.protocol" -> "https",
+        "microservice.services.eis.host" -> "foo",
+        "microservice.services.eis.port" -> "443"
+      )
+      .build()
+
+  private def testWithRunningApp(f: EuropaConnector => Unit): Unit = {
+    val app = configuredApplication
+    running(app) {
+      f(app.injector.instanceOf[EuropaConnector])
+    }
+  }
+
+}

--- a/test/uk/gov/hmrc/eusubsidycompliance/connectors/EuropaConnectorSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliance/connectors/EuropaConnectorSpec.scala
@@ -24,6 +24,7 @@ import org.scalatest.wordspec.AnyWordSpecLike
 import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.Helpers.running
+import uk.gov.hmrc.eusubsidycompliance.models.ExchangeRate
 import uk.gov.hmrc.eusubsidycompliance.test.util.WiremockSupport
 import uk.gov.hmrc.http.{HeaderCarrier, UpstreamErrorResponse}
 
@@ -158,7 +159,7 @@ class EuropaConnectorSpec extends AnyWordSpecLike
 
         testWithRunningApp { underTest =>
           val result = underTest.retrieveExchangeRate(date)
-          result.futureValue mustBe EuropaResponse("GBP", "EUR", BigDecimal(0.84135))
+          result.futureValue mustBe ExchangeRate("GBP", "EUR", BigDecimal(0.84135))
         }
       }
 

--- a/test/uk/gov/hmrc/eusubsidycompliance/connectors/EuropaConnectorSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliance/connectors/EuropaConnectorSpec.scala
@@ -24,7 +24,7 @@ import org.scalatest.wordspec.AnyWordSpecLike
 import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.Helpers.running
-import uk.gov.hmrc.eusubsidycompliance.models.ExchangeRate
+import uk.gov.hmrc.eusubsidycompliance.test.Fixtures.exchangeRate
 import uk.gov.hmrc.eusubsidycompliance.test.util.WiremockSupport
 import uk.gov.hmrc.http.{HeaderCarrier, UpstreamErrorResponse}
 
@@ -62,7 +62,7 @@ class EuropaConnectorSpec extends AnyWordSpecLike
       |                "0:0:0:0:0": {
       |                    "observations": {
       |                        "0": [
-      |                            0.84135
+      |                            0.8
       |                        ]
       |                    }
       |                }
@@ -159,7 +159,7 @@ class EuropaConnectorSpec extends AnyWordSpecLike
 
         testWithRunningApp { underTest =>
           val result = underTest.retrieveExchangeRate(date)
-          result.futureValue mustBe ExchangeRate("GBP", "EUR", BigDecimal(0.84135))
+          result.futureValue mustBe exchangeRate
         }
       }
 

--- a/test/uk/gov/hmrc/eusubsidycompliance/connectors/EuropaConnectorSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliance/connectors/EuropaConnectorSpec.scala
@@ -164,33 +164,6 @@ class EuropaConnectorSpec extends AnyWordSpecLike
 
     "an exchange rate request is made" should {
 
-//      "parse responses for all dates" in {
-
-
-//        val startDate = LocalDate.of(2020, 4, 6)
-
-//        val dates = (0 to 30).map { i =>
-//          val month = startDate.plusMonths(i)
-//          month.withDayOfMonth(month.getMonth.length(month.isLeapYear) - 1)
-//        }
-
-//        testWithRunningApp { underTest =>
-
-//          dates.foreach { date =>
-//            if (date.isAfter(LocalDate.now())) println(s"Skipping $date - in future")
-//            else {
-//              println(s"Fetching rate for $date")
-//              val result = underTest.retrieveExchangeRate(date)
-//              val rate = result.futureValue.rate
-//              println(s"$date GBP:EUR $rate")
-//              (rate > 0) mustBe true
-//            }
-//          }
-
-//        }
-
-//      }
-
       "return a successful response for a valid response from the europa API" in {
         givenEuropaReturns(200, requestUrl, validResponse)
 
@@ -230,9 +203,6 @@ class EuropaConnectorSpec extends AnyWordSpecLike
         "microservice.services.europa.port" -> server.port()
       ).build()
 
-  //        "microservice.services.europa.protocol" -> "https",
-  //        "microservice.services.europa.host" -> "sdw-wsrest.ecb.europa.eu",
-  //        "microservice.services.europa.port" -> 443,
 
   private def testWithRunningApp(f: EuropaConnector => Unit): Unit = {
     val app = configuredApplication

--- a/test/uk/gov/hmrc/eusubsidycompliance/connectors/EuropaConnectorSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliance/connectors/EuropaConnectorSpec.scala
@@ -16,34 +16,169 @@
 
 package uk.gov.hmrc.eusubsidycompliance.connectors
 
+import com.fasterxml.jackson.core.JsonParseException
+import com.github.tomakehurst.wiremock.client.WireMock._
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.Helpers.running
-import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.eusubsidycompliance.test.util.WiremockSupport
+import uk.gov.hmrc.http.{HeaderCarrier, UpstreamErrorResponse}
 
 import java.time.LocalDate
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class EuropaConnectorSpec extends AnyWordSpecLike
   with Matchers
+  with WiremockSupport
   with ScalaFutures
   with IntegrationPatience {
 
   implicit private val hc: HeaderCarrier = HeaderCarrier()
 
+  private val date = LocalDate.of(2022, 1, 3)
+
+  private val requestUrl =
+    s"/service/data/EXR/D.GBP.EUR.SP00.A?startPeriod=$date&endPeriod=$date&detail=dataonly&lastNObservations=1"
+
+  private val validResponse =
+    """{
+      |    "header": {
+      |        "id": "972803cb-94d7-4342-a6ec-a69edf56041d",
+      |        "test": false,
+      |        "prepared": "2022-06-22T12:32:42.940+02:00",
+      |        "sender": {
+      |            "id": "ECB"
+      |        }
+      |    },
+      |    "dataSets": [
+      |        {
+      |            "action": "Replace",
+      |            "validFrom": "2022-06-22T12:32:42.940+02:00",
+      |            "series": {
+      |                "0:0:0:0:0": {
+      |                    "observations": {
+      |                        "0": [
+      |                            0.84135
+      |                        ]
+      |                    }
+      |                }
+      |            }
+      |        }
+      |    ],
+      |    "structure": {
+      |        "links": [
+      |            {
+      |                "title": "Exchange Rates",
+      |                "rel": "dataflow",
+      |                "href": "https://sdw-wsrest.ecb.europa.eu:443/service/dataflow/ECB/EXR/1.0"
+      |            }
+      |        ],
+      |        "name": "Exchange Rates",
+      |        "dimensions": {
+      |            "series": [
+      |                {
+      |                    "id": "FREQ",
+      |                    "name": "Frequency",
+      |                    "values": [
+      |                        {
+      |                            "id": "D",
+      |                            "name": "Daily"
+      |                        }
+      |                    ]
+      |                },
+      |                {
+      |                    "id": "CURRENCY",
+      |                    "name": "Currency",
+      |                    "values": [
+      |                        {
+      |                            "id": "GBP",
+      |                            "name": "UK pound sterling"
+      |                        }
+      |                    ]
+      |                },
+      |                {
+      |                    "id": "CURRENCY_DENOM",
+      |                    "name": "Currency denominator",
+      |                    "values": [
+      |                        {
+      |                            "id": "EUR",
+      |                            "name": "Euro"
+      |                        }
+      |                    ]
+      |                },
+      |                {
+      |                    "id": "EXR_TYPE",
+      |                    "name": "Exchange rate type",
+      |                    "values": [
+      |                        {
+      |                            "id": "SP00",
+      |                            "name": "Spot"
+      |                        }
+      |                    ]
+      |                },
+      |                {
+      |                    "id": "EXR_SUFFIX",
+      |                    "name": "Series variation - EXR context",
+      |                    "values": [
+      |                        {
+      |                            "id": "A",
+      |                            "name": "Average"
+      |                        }
+      |                    ]
+      |                }
+      |            ],
+      |            "observation": [
+      |                {
+      |                    "id": "TIME_PERIOD",
+      |                    "name": "Time period or range",
+      |                    "role": "time",
+      |                    "values": [
+      |                        {
+      |                            "id": "2022-01-03",
+      |                            "name": "2022-01-03",
+      |                            "start": "2022-01-03T00:00:00.000+01:00",
+      |                            "end": "2022-01-03T23:59:59.999+01:00"
+      |                        }
+      |                    ]
+      |                }
+      |            ]
+      |        }
+      |    }
+      |}""".stripMargin
+
   "EuropaConnector" when {
 
-    // TODO - initial placeholder to verify that we can hit the real API and parse the response
-    "a request is made" in {
+    "an exchange rate request is made" should {
 
-      testWithRunningApp { underTest =>
-        val result = underTest.retrieveExchangeRate("GBP", "EUR", LocalDate.of(2022, 4, 29))
-        result.futureValue mustBe EuropaResponse("EUR", "GBP", BigDecimal(0.84135))
+      "return a successful response for a valid response from the europa API" in {
+        givenEuropaReturns(200, requestUrl, validResponse)
+
+        testWithRunningApp { underTest =>
+          val result = underTest.retrieveExchangeRate(date)
+          result.futureValue mustBe EuropaResponse("GBP", "EUR", BigDecimal(0.84135))
+        }
       }
 
+      "throw a JsonParseException for a response that could not be parsed" in {
+        givenEuropaReturns(200, requestUrl, "This is not a valid JSON response")
+
+        testWithRunningApp { underTest =>
+          val result = underTest.retrieveExchangeRate(date)
+          result.failed.futureValue mustBe a[JsonParseException]
+        }
+      }
+
+      "throw an UpstreamErrorResponse for an internal server error response " in {
+        givenEuropaReturns(500, requestUrl, "Error")
+
+        testWithRunningApp { underTest =>
+          val result = underTest.retrieveExchangeRate(date)
+          result.failed.futureValue mustBe a[UpstreamErrorResponse]
+        }
+      }
 
     }
 
@@ -52,10 +187,9 @@ class EuropaConnectorSpec extends AnyWordSpecLike
   private def configuredApplication: Application =
     new GuiceApplicationBuilder()
       .configure(
-        // TODO - configure this to point to wiremock
-        "microservice.services.eis.protocol" -> "https",
-        "microservice.services.eis.host" -> "foo",
-        "microservice.services.eis.port" -> "443"
+        "microservice.services.europa.protocol" -> "http",
+        "microservice.services.europa.host" -> "localhost",
+        "microservice.services.europa.port" -> server.port()
       )
       .build()
 
@@ -65,5 +199,15 @@ class EuropaConnectorSpec extends AnyWordSpecLike
       f(app.injector.instanceOf[EuropaConnector])
     }
   }
+
+  private def givenEuropaReturns(status: Int, url: String, responseBody: String): Unit =
+    server.stubFor(
+      get(urlEqualTo(url))
+        .willReturn(
+          aResponse()
+            .withStatus(status)
+            .withBody(responseBody)
+        )
+    )
 
 }

--- a/test/uk/gov/hmrc/eusubsidycompliance/connectors/EuropaConnectorSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliance/connectors/EuropaConnectorSpec.scala
@@ -40,16 +40,17 @@ class EuropaConnectorSpec extends AnyWordSpecLike
   implicit private val hc: HeaderCarrier = HeaderCarrier()
 
   private val date = LocalDate.of(2022, 1, 3)
+  private val yearMonth = "2022-01"
 
   private val requestUrl =
-    s"/service/data/EXR/D.GBP.EUR.SP00.A?startPeriod=$date&endPeriod=$date&detail=dataonly&lastNObservations=1"
+    s"/service/data/EXR/D.GBP.EUR.SP00.A?startPeriod=$yearMonth&endPeriod=$yearMonth&detail=dataonly&lastNObservations=2"
 
   private val validResponse =
     """{
       |    "header": {
-      |        "id": "972803cb-94d7-4342-a6ec-a69edf56041d",
+      |        "id": "dfd59cc9-9f2b-4bb1-905d-42b22f1780c6",
       |        "test": false,
-      |        "prepared": "2022-06-22T12:32:42.940+02:00",
+      |        "prepared": "2022-06-27T17:18:59.359+02:00",
       |        "sender": {
       |            "id": "ECB"
       |        }
@@ -57,12 +58,15 @@ class EuropaConnectorSpec extends AnyWordSpecLike
       |    "dataSets": [
       |        {
       |            "action": "Replace",
-      |            "validFrom": "2022-06-22T12:32:42.940+02:00",
+      |            "validFrom": "2022-06-27T17:18:59.359+02:00",
       |            "series": {
       |                "0:0:0:0:0": {
       |                    "observations": {
       |                        "0": [
       |                            0.8
+      |                        ],
+      |                        "1": [
+      |                            0.90088
       |                        ]
       |                    }
       |                }
@@ -138,10 +142,16 @@ class EuropaConnectorSpec extends AnyWordSpecLike
       |                    "role": "time",
       |                    "values": [
       |                        {
-      |                            "id": "2022-01-03",
-      |                            "name": "2022-01-03",
-      |                            "start": "2022-01-03T00:00:00.000+01:00",
-      |                            "end": "2022-01-03T23:59:59.999+01:00"
+      |                            "id": "2020-05-28",
+      |                            "name": "2020-05-28",
+      |                            "start": "2020-05-28T00:00:00.000+02:00",
+      |                            "end": "2020-05-28T23:59:59.999+02:00"
+      |                        },
+      |                        {
+      |                            "id": "2020-05-29",
+      |                            "name": "2020-05-29",
+      |                            "start": "2020-05-29T00:00:00.000+02:00",
+      |                            "end": "2020-05-29T23:59:59.999+02:00"
       |                        }
       |                    ]
       |                }
@@ -153,6 +163,33 @@ class EuropaConnectorSpec extends AnyWordSpecLike
   "EuropaConnector" when {
 
     "an exchange rate request is made" should {
+
+//      "parse responses for all dates" in {
+
+
+//        val startDate = LocalDate.of(2020, 4, 6)
+
+//        val dates = (0 to 30).map { i =>
+//          val month = startDate.plusMonths(i)
+//          month.withDayOfMonth(month.getMonth.length(month.isLeapYear) - 1)
+//        }
+
+//        testWithRunningApp { underTest =>
+
+//          dates.foreach { date =>
+//            if (date.isAfter(LocalDate.now())) println(s"Skipping $date - in future")
+//            else {
+//              println(s"Fetching rate for $date")
+//              val result = underTest.retrieveExchangeRate(date)
+//              val rate = result.futureValue.rate
+//              println(s"$date GBP:EUR $rate")
+//              (rate > 0) mustBe true
+//            }
+//          }
+
+//        }
+
+//      }
 
       "return a successful response for a valid response from the europa API" in {
         givenEuropaReturns(200, requestUrl, validResponse)
@@ -191,8 +228,11 @@ class EuropaConnectorSpec extends AnyWordSpecLike
         "microservice.services.europa.protocol" -> "http",
         "microservice.services.europa.host" -> "localhost",
         "microservice.services.europa.port" -> server.port()
-      )
-      .build()
+      ).build()
+
+  //        "microservice.services.europa.protocol" -> "https",
+  //        "microservice.services.europa.host" -> "sdw-wsrest.ecb.europa.eu",
+  //        "microservice.services.europa.port" -> 443,
 
   private def testWithRunningApp(f: EuropaConnector => Unit): Unit = {
     val app = configuredApplication

--- a/test/uk/gov/hmrc/eusubsidycompliance/connectors/EuropaConnectorSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliance/connectors/EuropaConnectorSpec.scala
@@ -168,7 +168,7 @@ class EuropaConnectorSpec extends AnyWordSpecLike
         givenEuropaReturns(200, requestUrl, validResponse)
 
         testWithRunningApp { underTest =>
-          val result = underTest.retrieveExchangeRate(date)
+          val result = underTest.retrieveApplicableExchangeRate(date)
           result.futureValue mustBe exchangeRate
         }
       }
@@ -177,7 +177,7 @@ class EuropaConnectorSpec extends AnyWordSpecLike
         givenEuropaReturns(200, requestUrl, "This is not a valid JSON response")
 
         testWithRunningApp { underTest =>
-          val result = underTest.retrieveExchangeRate(date)
+          val result = underTest.retrieveApplicableExchangeRate(date)
           result.failed.futureValue mustBe a[JsonParseException]
         }
       }
@@ -186,7 +186,7 @@ class EuropaConnectorSpec extends AnyWordSpecLike
         givenEuropaReturns(500, requestUrl, "Error")
 
         testWithRunningApp { underTest =>
-          val result = underTest.retrieveExchangeRate(date)
+          val result = underTest.retrieveApplicableExchangeRate(date)
           result.failed.futureValue mustBe a[UpstreamErrorResponse]
         }
       }

--- a/test/uk/gov/hmrc/eusubsidycompliance/controllers/ExchangeRateControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliance/controllers/ExchangeRateControllerSpec.scala
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.eusubsidycompliance.controllers
+
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
+import org.scalatestplus.play.PlaySpec
+import play.api.inject.bind
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.json.Json
+import play.api.mvc.{ControllerComponents, Request, Result}
+import play.api.test.Helpers.{GET, contentAsJson, defaultAwaitTimeout, route, running, status, writeableOf_AnyContentAsEmpty}
+import play.api.test.{FakeRequest, Helpers}
+import uk.gov.hmrc.auth.core.AuthConnector
+import uk.gov.hmrc.eusubsidycompliance.controllers.actions.Auth
+import uk.gov.hmrc.eusubsidycompliance.models.ExchangeRate
+import uk.gov.hmrc.eusubsidycompliance.services.ExchangeRateService
+import uk.gov.hmrc.eusubsidycompliance.test.Fixtures.eori
+import uk.gov.hmrc.http.HeaderCarrier
+
+import java.time.LocalDate
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.{ExecutionContext, Future}
+
+class ExchangeRateControllerSpec extends PlaySpec with MockFactory with ScalaFutures with IntegrationPatience {
+
+  // TODO - move this out into a shared location - copied verbatim from UndertakingControllerSpec
+  // FakeAuthenticator that allows every request.
+  private class FakeAuth extends Auth {
+    override def authCommon[A](
+      action: AuthAction[A]
+    )(implicit request: Request[A], executionContext: ExecutionContext): Future[Result] = action(request)(eori)
+    override protected def controllerComponents: ControllerComponents = Helpers.stubControllerComponents()
+    // This isn't used in this implementation so can be left as unimplemented.
+    override def authConnector: AuthConnector = ???
+  }
+
+  private val mockExchangeRateService = mock[ExchangeRateService]
+
+  "ExchangeRateController" when {
+
+    "getExchangeRate is called" should {
+
+      "return a successful response for a valid request" in {
+
+        val app = configuredAppInstance
+
+        givenExchangeRateServiceReturns(LocalDate.of(2022, 2, 3))(Future(ExchangeRate("EUR", "GBP", BigDecimal(0.80))))
+
+        running(app) {
+          val request =
+            FakeRequest(GET, routes.ExchangeRateController.getExchangeRate("2022-02-03").url)
+
+          val result = route(app, request).value
+
+          status(result) mustBe 200
+          contentAsJson(result) mustBe Json.toJson(ExchangeRate("EUR", "GBP", BigDecimal(0.80)))
+        }
+
+      }
+
+    }
+
+  }
+
+  private def configuredAppInstance = new GuiceApplicationBuilder()
+    .configure(
+      "metrics.jvm" -> false,
+      "microservice.metrics.graphite.enabled" -> false
+    )
+    .overrides(
+      bind[ExchangeRateService].to(mockExchangeRateService),
+      bind[Auth].to(new FakeAuth)
+    )
+    .build()
+
+  def givenExchangeRateServiceReturns(date: LocalDate)(res: Future[ExchangeRate]): Unit =
+    (mockExchangeRateService
+      .getExchangeRate(_: LocalDate)(_: HeaderCarrier))
+      .expects(date, *)
+      .returning(res)
+
+}

--- a/test/uk/gov/hmrc/eusubsidycompliance/controllers/UndertakingControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliance/controllers/UndertakingControllerSpec.scala
@@ -23,16 +23,15 @@ import play.api.http.Status
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.{Format, Json}
-import play.api.mvc.{ControllerComponents, Request, Result}
+import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import play.api.test.{FakeRequest, Helpers}
-import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.eusubsidycompliance.connectors.EisConnector
 import uk.gov.hmrc.eusubsidycompliance.controllers.actions.Auth
-import uk.gov.hmrc.eusubsidycompliance.models.types.AmendmentType.AmendmentType
-import uk.gov.hmrc.eusubsidycompliance.models.types.{AmendmentType, EORI, EisAmendmentType, UndertakingRef}
 import uk.gov.hmrc.eusubsidycompliance.models._
+import uk.gov.hmrc.eusubsidycompliance.models.types.AmendmentType.AmendmentType
 import uk.gov.hmrc.eusubsidycompliance.models.types.EisAmendmentType.EisAmendmentType
+import uk.gov.hmrc.eusubsidycompliance.models.types.{AmendmentType, EORI, EisAmendmentType, UndertakingRef}
+import uk.gov.hmrc.eusubsidycompliance.test.FakeAuth
 import uk.gov.hmrc.eusubsidycompliance.test.Fixtures._
 import uk.gov.hmrc.eusubsidycompliance.util.TimeProvider
 import uk.gov.hmrc.http.HeaderCarrier
@@ -41,16 +40,6 @@ import java.time.LocalDate
 import scala.concurrent.{ExecutionContext, Future}
 
 class UndertakingControllerSpec extends PlaySpec with MockFactory with ScalaFutures with IntegrationPatience {
-
-  // FakeAuthenticator that allows every request.
-  private class FakeAuth extends Auth {
-    override def authCommon[A](
-      action: AuthAction[A]
-    )(implicit request: Request[A], executionContext: ExecutionContext): Future[Result] = action(request)(eori)
-    override protected def controllerComponents: ControllerComponents = Helpers.stubControllerComponents()
-    // This isn't used in this implementation so can be left as unimplemented.
-    override def authConnector: AuthConnector = ???
-  }
 
   private val mockEisConnector = mock[EisConnector]
   private val mockTimeProvider = mock[TimeProvider]

--- a/test/uk/gov/hmrc/eusubsidycompliance/services/ExchangeRateServiceSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliance/services/ExchangeRateServiceSpec.scala
@@ -47,12 +47,12 @@ class ExchangeRateServiceSpec extends AnyWordSpecLike
     "getExchangeRate is called" should {
 
       "return a successful response for a valid date" in {
-        givenEuropaConnectorReturns(LocalDate.of(2022, 3, 30))(Future(exchangeRate))
+        givenEuropaConnectorReturns(LocalDate.of(2022, 3, 1))(Future(exchangeRate))
         underTest.getExchangeRate(LocalDate.of(2022, 4, 22)).futureValue shouldBe exchangeRate
       }
 
       "correctly compute the exchange rate date across a year boundary" in {
-        givenEuropaConnectorReturns(LocalDate.of(2021, 12, 30))(Future(exchangeRate))
+        givenEuropaConnectorReturns(LocalDate.of(2021, 12, 1))(Future(exchangeRate))
         underTest.getExchangeRate(LocalDate.of(2022, 1, 22)).futureValue shouldBe exchangeRate
       }
 

--- a/test/uk/gov/hmrc/eusubsidycompliance/services/ExchangeRateServiceSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliance/services/ExchangeRateServiceSpec.scala
@@ -62,7 +62,7 @@ class ExchangeRateServiceSpec extends AnyWordSpecLike
 
   private def givenEuropaConnectorReturns(date: LocalDate)(res: Future[ExchangeRate]): Unit =
     (mockConnector
-      .retrieveExchangeRate(_: LocalDate)(_: HeaderCarrier, _: ExecutionContext))
+      .retrieveApplicableExchangeRate(_: LocalDate)(_: HeaderCarrier, _: ExecutionContext))
       .expects(date, *, *)
       .returning(res)
 

--- a/test/uk/gov/hmrc/eusubsidycompliance/services/ExchangeRateServiceSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliance/services/ExchangeRateServiceSpec.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.eusubsidycompliance.services
+
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+import uk.gov.hmrc.eusubsidycompliance.connectors.EuropaConnector
+import uk.gov.hmrc.eusubsidycompliance.models.ExchangeRate
+import uk.gov.hmrc.http.HeaderCarrier
+
+import java.time.LocalDate
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.{ExecutionContext, Future}
+
+class ExchangeRateServiceSpec extends AnyWordSpecLike
+  with Matchers
+  with MockFactory
+  with ScalaFutures
+  with IntegrationPatience {
+
+  private val mockConnector = mock[EuropaConnector]
+
+  private implicit val headerCarrier: HeaderCarrier = mock[HeaderCarrier]
+
+  private val underTest = new ExchangeRateService(mockConnector)
+
+  private val exchangeRate = ExchangeRate("GBP", "EUR", BigDecimal(0.80))
+
+  "ExchangeRateService" when {
+
+    "getExchangeRate is called" should {
+
+      "return a successful response for a valid date" in {
+        givenEuropaConnectorReturns(LocalDate.of(2022, 3, 30))(Future(exchangeRate))
+        underTest.getExchangeRate(LocalDate.of(2022, 4, 22)).futureValue shouldBe exchangeRate
+      }
+
+      "correctly compute the exchange rate date across a year boundary" in {
+        givenEuropaConnectorReturns(LocalDate.of(2021, 12, 30))(Future(exchangeRate))
+        underTest.getExchangeRate(LocalDate.of(2022, 1, 22)).futureValue shouldBe exchangeRate
+      }
+
+    }
+
+  }
+
+  private def givenEuropaConnectorReturns(date: LocalDate)(res: Future[ExchangeRate]): Unit =
+    (mockConnector
+      .retrieveExchangeRate(_: LocalDate)(_: HeaderCarrier, _: ExecutionContext))
+      .expects(date, *, *)
+      .returning(res)
+
+}

--- a/test/uk/gov/hmrc/eusubsidycompliance/test/FakeAuth.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliance/test/FakeAuth.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.eusubsidycompliance.test
+
+import play.api.mvc.{ControllerComponents, Request, Result}
+import play.api.test.Helpers
+import uk.gov.hmrc.auth.core.AuthConnector
+import uk.gov.hmrc.eusubsidycompliance.controllers.actions.Auth
+import uk.gov.hmrc.eusubsidycompliance.test.Fixtures.eori
+
+import scala.concurrent.{ExecutionContext, Future}
+
+// Fake authenticator that allows every request.
+class FakeAuth extends Auth {
+  override def authCommon[A](
+    action: AuthAction[A]
+  )(implicit request: Request[A], executionContext: ExecutionContext): Future[Result] = action(request)(eori)
+  override protected def controllerComponents: ControllerComponents = Helpers.stubControllerComponents()
+  // This isn't used in this implementation so can be left as unimplemented.
+  override def authConnector: AuthConnector = ???
+}

--- a/test/uk/gov/hmrc/eusubsidycompliance/test/Fixtures.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliance/test/Fixtures.scala
@@ -91,6 +91,6 @@ object Fixtures {
     hmrcSubsidyUsage = List(hmrcSubsidy)
   )
 
-  val exchangeRate = ExchangeRate("EUR", "GBP", BigDecimal(0.80))
+  val exchangeRate = ExchangeRate(BigDecimal(0.80))
 
 }

--- a/test/uk/gov/hmrc/eusubsidycompliance/test/Fixtures.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliance/test/Fixtures.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.eusubsidycompliance.test
 
-import uk.gov.hmrc.eusubsidycompliance.models.{BusinessEntity, HmrcSubsidy, NonHmrcSubsidy, UndertakingCreate, UndertakingRetrieve, UndertakingSubsidies}
+import uk.gov.hmrc.eusubsidycompliance.models.{BusinessEntity, ExchangeRate, HmrcSubsidy, NonHmrcSubsidy, UndertakingCreate, UndertakingRetrieve, UndertakingSubsidies}
 import uk.gov.hmrc.eusubsidycompliance.models.types.{DeclarationID, EORI, IndustrySectorLimit, Sector, SubsidyAmount, SubsidyRef, TaxType, TraderRef, UndertakingName, UndertakingRef}
 
 import java.time.{Instant, ZoneId}
@@ -90,5 +90,7 @@ object Fixtures {
     nonHMRCSubsidyUsage = List(nonHmrcSubsidy),
     hmrcSubsidyUsage = List(hmrcSubsidy)
   )
+
+  val exchangeRate = ExchangeRate("EUR", "GBP", BigDecimal(0.80))
 
 }


### PR DESCRIPTION
Summary of changes
* integrate with Europa API to fetch GBP to EUR rates for a given date
* add GET route for the frontend service to fetch rates for the subsidy flow
* added tests and other minor changes