### PR TITLE
ESC-639 add proxy support to europa connector

### DIFF
--- a/app/uk/gov/hmrc/eusubsidycompliance/connectors/EuropaConnector.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliance/connectors/EuropaConnector.scala
@@ -17,8 +17,8 @@
 package uk.gov.hmrc.eusubsidycompliance.connectors
 
 import uk.gov.hmrc.eusubsidycompliance.models.ExchangeRate
+import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.HttpReads.Implicits._
-import uk.gov.hmrc.http.{HeaderCarrier, HttpClient}
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
 import java.time.LocalDate
@@ -31,7 +31,7 @@ import scala.concurrent.{ExecutionContext, Future}
  */
 @Singleton
 class EuropaConnector @Inject() (
-  val client: HttpClient,
+  val client: ProxiedHttpClient,
   val servicesConfig: ServicesConfig
 ) {
 

--- a/app/uk/gov/hmrc/eusubsidycompliance/connectors/ProxiedHttpClient.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliance/connectors/ProxiedHttpClient.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.eusubsidycompliance.connectors
+
+import akka.actor.ActorSystem
+import play.api.Configuration
+import play.api.libs.ws.{WSClient, WSProxyServer}
+import uk.gov.hmrc.eusubsidycompliance.config.AppConfig
+import uk.gov.hmrc.play.audit.http.HttpAuditing
+import uk.gov.hmrc.play.bootstrap.http.DefaultHttpClient
+import uk.gov.hmrc.play.http.ws.{WSProxy, WSProxyConfiguration}
+
+import javax.inject.{Singleton,Inject}
+
+@Singleton
+class ProxiedHttpClient @Inject()(
+  configuration: Configuration,
+  httpAuditing: HttpAuditing,
+  wsClient: WSClient,
+  actorSystem: ActorSystem,
+  config: AppConfig)
+  extends DefaultHttpClient(configuration, httpAuditing, wsClient, actorSystem) with WSProxy {
+
+  override def wsProxyServer: Option[WSProxyServer] = WSProxyConfiguration("proxy", configuration)
+
+}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -155,3 +155,7 @@ microservice {
   }
 }
 
+# Default proxy configuration.
+proxy {
+  proxyRequiredForThisEnvironment: false
+}

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -6,7 +6,7 @@ import sbt._
 object AppDependencies {
 
   val bootStrapVersion = "5.23.0"
-  val hmrcMongoVersion = "0.63.0"
+  val hmrcMongoVersion = "0.68.0"
 
   val compile = Seq(
     "uk.gov.hmrc"       %% "bootstrap-backend-play-28" % bootStrapVersion,


### PR DESCRIPTION
Summary of changes
* introduce a proxed HTTP client that picks up proxy settings from the application config
* provide explicit default config to disable use of the proxy (internally it defaults to on - this will be overriden in the QA and Production configs) 