### PR TITLE
ESC-844 bump sbt and plugin versions

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.9
+sbt.version=1.6.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefact
 )
 resolvers += Resolver.typesafeRepo("releases")
 
-addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"     % "3.6.0")
+addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"     % "3.8.0")
 addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables" % "2.1.0")
-addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % "2.8.7")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % "2.8.18")
 addSbtPlugin("org.scoverage"     % "sbt-scoverage"      % "1.9.3")

--- a/test/uk/gov/hmrc/eusubsidycompliance/controllers/UndertakingControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliance/controllers/UndertakingControllerSpec.scala
@@ -108,7 +108,7 @@ class UndertakingControllerSpec extends PlaySpec with MockFactory with ScalaFutu
 
         givenUpdateUndertaking(Future.successful(undertakingReference), EisAmendmentType.A)
         running(app) {
-          val request = FakeRequest(POST, routes.UndertakingController.updateUndertaking().url)
+          val request = FakeRequest(POST, routes.UndertakingController.updateUndertaking.url)
             .withJsonBody(Json.toJson(undertaking))
             .withHeaders("Content-type" -> "application/json")
           val result = route(app, request).value
@@ -183,7 +183,7 @@ class UndertakingControllerSpec extends PlaySpec with MockFactory with ScalaFutu
         val app = configuredAppInstance
 
         running(app) {
-          val request = FakeRequest(POST, routes.UndertakingController.create().url)
+          val request = FakeRequest(POST, routes.UndertakingController.create.url)
             .withJsonBody(Json.toJson(undertaking))
             .withHeaders("Content-type" -> "application/json")
 
@@ -200,7 +200,7 @@ class UndertakingControllerSpec extends PlaySpec with MockFactory with ScalaFutu
         val app = configuredAppInstance
 
         running(app) {
-          val request = FakeRequest(POST, routes.UndertakingController.create().url)
+          val request = FakeRequest(POST, routes.UndertakingController.create.url)
             .withJsonBody(Json.toJson(undertaking))
             .withHeaders("Content-type" -> "application/json")
 
@@ -216,7 +216,7 @@ class UndertakingControllerSpec extends PlaySpec with MockFactory with ScalaFutu
         val app = configuredAppInstance
 
         running(app) {
-          val request = FakeRequest(POST, routes.UndertakingController.create().url)
+          val request = FakeRequest(POST, routes.UndertakingController.create.url)
             .withJsonBody(Json.toJson(undertaking))
             .withHeaders("Content-type" -> "application/json")
 


### PR DESCRIPTION
Summary of changes
* bumped the sbt version to that installed on the build boxes to avoid the penalty of downloading another SBT version during each build
* bumped other plugin versions including the play sbt plugin which necessitated some changes code referencing the routes